### PR TITLE
ndvi process: default to output band name "ndvi"

### DIFF
--- a/ndvi.json
+++ b/ndvi.json
@@ -17,10 +17,10 @@
             "required": true
         },
         "name": {
-            "description": "Name of the newly created band with the computed values. Defaults to `normalized_difference`.",
+            "description": "Name of the newly created band with the computed values. Defaults to `ndvi`.",
             "schema": {
                 "type": "string",
-                "default": "normalized_difference",
+                "default": "ndvi",
                 "pattern": "^[A-Za-z0-9_]+$"
             }
         }


### PR DESCRIPTION
Maybe I'm missing something, but it seems more logical to call the output "ndvi"  instead of "normalized_difference"
