### PR TITLE
Improvements for comparison processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `resample_spatial`: Default value of parameter `align` changed from `lower-left` to `upper-left`. [#61](https://github.com/Open-EO/openeo-processes/issues/61)
 - The following operations work on two values instead on a sequence of values: `and`, `divide`, `multiply`, `or`, `subtract`, `xor`. [#85](https://github.com/Open-EO/openeo-processes/issues/85)
 - `product` works as before, but is not an alias of `multiply` any longer. [#85](https://github.com/Open-EO/openeo-processes/issues/85)
+- `text_begins`, `text_contains`, `text_ends`: `null` values are supported and get passed through.
 
 ### Deprecated
 - `filter_bbox`, `load_collection`, `resample_spatial`: PROJ definitions are deprecated in favor of EPSG codes, WKT2 and PROJJSON. [#58](https://github.com/Open-EO/openeo-processes/issues/58)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Schema format/subtype `callback` has been renamed to `process-graph`.
 - Default values are now specified on the parameter-level, not in the JSON schemas.
 - Processes supporting multiple data types in parameters or return values with `anyOf` are now listing the data types directly as array. `anyOf` is discouraged.
+- Comparison processes `eq`, `gt`, `gte`, `lt`, `lte`, `neq` and `between` accept all data types as input for the operands.
 - `add_dimension`: Parameter `value` renamed to `label`.
 - `aggregate_polygon`: The data cube implicitly gets restricted to the bounds of the polygons as if `filter_polygon` would have been used beforehand. [#101](https://github.com/Open-EO/openeo-processes/issues/101)
 - `clip`: Works on a single value instead on arrays (replaced parameter `data` with `x`). [#75](https://github.com/Open-EO/openeo-processes/issues/75)
@@ -47,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Several clarifications in written texts. [#86](https://github.com/Open-EO/openeo-processes/issues/86)
+- `between` may return a `null` value.
 - `filter_bbox`, `load_collection`: The schema for the property `crs` in the parameters `extent`/`spatial_extent` contained invalid JSON Schema.
 
 ## [0.4.2] - 2019-06-11

--- a/array_contains.json
+++ b/array_contains.json
@@ -1,7 +1,7 @@
 {
     "id": "array_contains",
     "summary": "List contains an element",
-    "description": "Checks whether the array specified for `data` contains the value specified in `value`. Returns `true` if there's a match, otherwise `false`.\n\n**Remarks:**\n\n* To get the index of the element found, use ``array_find()``.\n* Data types MUST be checked strictly, for example a string with the content *1* is not equal to the number *1*.\n* An integer *1* is equal to a floating point number *1.0* as `integer` is a sub-type of `number`. Still, this process may return unexpectedly `false` when comparing floating point numbers due to floating point inaccuracy in machine-based computation.\n* Temporal strings are treated as normal strings and MUST NOT be interpreted.",
+    "description": "Checks whether the array specified for `data` contains the value specified in `value`. Returns `true` if there's a match, otherwise `false`.\n\n**Remarks:**\n\n* To get the index of the element found, use ``array_find()``.\n* All definitions for the process ``eq()`` regarding the comparison of values apply here as well. This includes that data types MUST be checked strictly, for example a string with the content *1* is not equal to the number *1*.\n* An integer *1* is equal to a floating point number *1.0* as `integer` is a sub-type of `number`. Still, this process may return unexpectedly `false` when comparing floating point numbers due to floating point inaccuracy in machine-based computation.\n* Temporal strings are treated as normal strings and MUST NOT be interpreted.",
     "categories": [
         "arrays",
         "comparison"

--- a/array_contains.json
+++ b/array_contains.json
@@ -108,7 +108,7 @@
                     2
                 ]
             },
-            "returns": true
+            "returns": false
         },
         {
             "arguments": {
@@ -140,7 +140,7 @@
                     "a": "b"
                 }
             },
-            "returns": true
+            "returns": false
         }
     ]
 }

--- a/array_find.json
+++ b/array_find.json
@@ -1,7 +1,7 @@
 {
     "id": "array_find",
     "summary": "Get the index of an element in an array",
-    "description": "Checks whether the array specified for `data` contains the value specified in `value` and returns the zero-based index for the first match. If there's no match, `-1` is returned.\n\n**Remarks:**\n\n* To get a boolean value returned use ``array_contains()``.\n* Data types MUST be checked strictly, for example a string with the content *1* is not equal to the number *1*.\n* An integer *1* is equal to a floating point number *1.0* as `integer` is a sub-type of `number`. Still, this process may return unexpectedly `false` when comparing floating point numbers due to floating point inaccuracy in machine-based computation.\n* Temporal strings are treated as normal strings and MUST NOT be interpreted.",
+    "description": "Checks whether the array specified for `data` contains the value specified in `value` and returns the zero-based index for the first match. If there's no match, `-1` is returned.\n\n**Remarks:**\n\n* To get a boolean value returned use ``array_contains()``.\n* All definitions for the process ``eq()`` regarding the comparison of values apply here as well. This includes that data types MUST be checked strictly, for example a string with the content *1* is not equal to the number *1*.\n* An integer *1* is equal to a floating point number *1.0* as `integer` is a sub-type of `number`. Still, this process may return unexpectedly `false` when comparing floating point numbers due to floating point inaccuracy in machine-based computation.\n* Temporal strings are treated as normal strings and MUST NOT be interpreted.",
     "categories": [
         "arrays"
     ],

--- a/array_find.json
+++ b/array_find.json
@@ -98,7 +98,7 @@
                     2
                 ]
             },
-            "returns": 0
+            "returns": -1
         },
         {
             "arguments": {
@@ -130,7 +130,7 @@
                     "a": "b"
                 }
             },
-            "returns": 0
+            "returns": -1
         }
     ]
 }

--- a/between.json
+++ b/between.json
@@ -1,7 +1,7 @@
 {
     "id": "between",
     "summary": "Between comparison",
-    "description": "By default this process checks whether `x` is greater than or equal to `min` and lower than or equal to `max`. Therefore, this process is an alias for `and([gte(x, min), lte(x, max)])` and all definitions from these processes apply here as well.\n\nIf `exclude_max` is set to `true` the upper bound is excluded so that the process checks whether `x` is greater than or equal to `min` and lower than `max`. In this case the process works the same as executing `and([gte(x, min), lt(x, max)])`.\n\nLower and upper bounds are not allowed to be swapped. So `min` MUST be lower than or equal to `max` or otherwise the process always returns `false`.",
+    "description": "By default this process checks whether `x` is greater than or equal to `min` and lower than or equal to `max`. Therefore, this process is an alias for `and([gte(x, min), lte(x, max)])` and all definitions from ``and()``, ``gte()`` and ``lte()`` apply here as well.\n\nIf `exclude_max` is set to `true` the upper bound is excluded so that the process checks whether `x` is greater than or equal to `min` and lower than `max`. In this case the process works the same as executing `and([gte(x, min), lt(x, max)])`.\n\nLower and upper bounds are not allowed to be swapped. So `min` MUST be lower than or equal to `max` or otherwise the process always returns `false`.",
     "categories": [
         "comparison"
     ],
@@ -14,29 +14,9 @@
     "parameters": {
         "x": {
             "description": "The value to check.",
-            "schema": [
-                {
-                    "type": "number"
-                },
-                {
-                    "type": "null"
-                },
-                {
-                    "type": "string",
-                    "format": "date-time",
-                    "subtype": "date-time"
-                },
-                {
-                    "type": "string",
-                    "format": "date",
-                    "subtype": "date"
-                },
-                {
-                    "type": "string",
-                    "format": "time",
-                    "subtype": "time"
-                }
-            ],
+            "schema": {
+                "description": "Any data type is allowed."
+            },
             "required": true
         },
         "min": {
@@ -98,7 +78,10 @@
     "returns": {
         "description": "`true` if `x` is between the specified bounds, otherwise `false`.",
         "schema": {
-            "type": "boolean"
+            "type": [
+                "boolean",
+                "null"
+            ]
         }
     },
     "examples": [

--- a/eq.json
+++ b/eq.json
@@ -1,7 +1,7 @@
 {
     "id": "eq",
     "summary": "Equal to comparison",
-    "description": "Compares whether `x` is strictly equal to `y`.\n\n**Remarks:**\n\n* Data types MUST be checked strictly, for example a string with the content *1* is not equal to the number *1*. Nevertheless, an integer *1* is equal to a floating point number *1.0* as `integer` is a sub-type of `number`.\n* If any operand is `null`, the return value is `null`.\n* Strings are expected to be encoded in UTF-8 by default.\n* Temporal strings MUST be compared differently than other strings and MUST NOT be compared based on their string representation due to different possible representations. For example, the UTC time zone representation `Z` has the same meaning as `+00:00`.",
+    "description": "Compares whether `x` is strictly equal to `y`.\n\n**Remarks:**\n\n* Data types MUST be checked strictly, for example a string with the content *1* is not equal to the number *1*. Nevertheless, an integer *1* is equal to a floating point number *1.0* as `integer` is a sub-type of `number`.\n* If any operand is `null`, the return value is `null`.\n* If any operand is an array or object, the return value is `false`.\n* Strings are expected to be encoded in UTF-8 by default.\n* Temporal strings MUST be compared differently than other strings and MUST NOT be compared based on their string representation due to different possible representations. For example, the UTC time zone representation `Z` has the same meaning as `+00:00`.",
     "categories": [
         "texts",
         "comparison"
@@ -156,13 +156,6 @@
         {
             "arguments": {
                 "x": [1,2,3],
-                "y": [1,2,3]
-            },
-            "returns": true
-        },
-        {
-            "arguments": {
-                "x": [3,2,1],
                 "y": [1,2,3]
             },
             "returns": false

--- a/eq.json
+++ b/eq.json
@@ -1,7 +1,7 @@
 {
     "id": "eq",
     "summary": "Equal to comparison",
-    "description": "Compares whether `x` is strictly equal to `y`.\n\n**Remarks:**\n\n* Data types MUST be checked strictly, for example a string with the content *1* is not equal to the number *1*. Nevertheless, an integer *1* is equal to a floating point number *1.0* as `integer` is a sub-type of `number`.\n* If any of the operands is `null`, the return value is `null`.\n* Strings are expected to be encoded in UTF-8 by default.\n* Temporal strings MUST be compared differently than other strings and MUST NOT be compared based on their string representation due to different possible representations. For example, the UTC time zone representation `Z` has the same meaning as `+00:00`.",
+    "description": "Compares whether `x` is strictly equal to `y`.\n\n**Remarks:**\n\n* Data types MUST be checked strictly, for example a string with the content *1* is not equal to the number *1*. Nevertheless, an integer *1* is equal to a floating point number *1.0* as `integer` is a sub-type of `number`.\n* If any operand is `null`, the return value is `null`.\n* Strings are expected to be encoded in UTF-8 by default.\n* Temporal strings MUST be compared differently than other strings and MUST NOT be compared based on their string representation due to different possible representations. For example, the UTC time zone representation `Z` has the same meaning as `+00:00`.",
     "categories": [
         "texts",
         "comparison"
@@ -15,68 +15,16 @@
     "parameters": {
         "x": {
             "description": "First operand.",
-            "schema": [
-                {
-                    "type": "number"
-                },
-                {
-                    "type": "boolean"
-                },
-                {
-                    "type": "null"
-                },
-                {
-                    "type": "string"
-                },
-                {
-                    "type": "string",
-                    "format": "date-time",
-                    "subtype": "date-time"
-                },
-                {
-                    "type": "string",
-                    "format": "date",
-                    "subtype": "date"
-                },
-                {
-                    "type": "string",
-                    "format": "time",
-                    "subtype": "time"
-                }
-            ],
+            "schema": {
+                "description": "Any data type is allowed."
+            },
             "required": true
         },
         "y": {
             "description": "Second operand.",
-            "schema": [
-                {
-                    "type": "number"
-                },
-                {
-                    "type": "boolean"
-                },
-                {
-                    "type": "null"
-                },
-                {
-                    "type": "string"
-                },
-                {
-                    "type": "string",
-                    "format": "date-time",
-                    "subtype": "date-time"
-                },
-                {
-                    "type": "string",
-                    "format": "date",
-                    "subtype": "date"
-                },
-                {
-                    "type": "string",
-                    "format": "time",
-                    "subtype": "time"
-                }
-            ],
+            "schema": {
+                "description": "Any data type is allowed."
+            },
             "required": true
         },
         "delta": {
@@ -98,7 +46,7 @@
         }
     },
     "returns": {
-        "description": "Returns `true` if `x` is equal to `y`, `null` if any of the operands is `null`, otherwise `false`.",
+        "description": "Returns `true` if `x` is equal to `y`, `null` if any operand is `null`, otherwise `false`.",
         "schema": {
             "type": [
                 "boolean",
@@ -204,6 +152,20 @@
                 "y": "2018-01-01T01:00:00+01:00"
             },
             "returns": true
+        },
+        {
+            "arguments": {
+                "x": [1,2,3],
+                "y": [1,2,3]
+            },
+            "returns": true
+        },
+        {
+            "arguments": {
+                "x": [3,2,1],
+                "y": [1,2,3]
+            },
+            "returns": false
         }
     ]
 }

--- a/gt.json
+++ b/gt.json
@@ -1,7 +1,7 @@
 {
     "id": "gt",
     "summary": "Greater than comparison",
-    "description": "Compares whether `x` is strictly greater than `y`.\n\n**Remarks:**\n\n* If any of the operands is `null`, the return value is `null`.\n* Temporal strings can *not* be compared based on their string representation due to the time zone / time-offset representations.\n* Comparing strings is currently not supported, but is planned to be added in the future.",
+    "description": "Compares whether `x` is strictly greater than `y`.\n\n**Remarks:**\n\n* If any operand is `null`, the return value is `null`. If any operand is not a `number` or temporal string (`date`, `time` or `date-time`), the process returns `false`.\n* Temporal strings can *not* be compared based on their string representation due to the time zone / time-offset representations.",
     "categories": [
         "comparison"
     ],
@@ -12,61 +12,21 @@
     "parameters": {
         "x": {
             "description": "First operand.",
-            "schema": [
-                {
-                    "type": "number"
-                },
-                {
-                    "type": "null"
-                },
-                {
-                    "type": "string",
-                    "format": "date-time",
-                    "subtype": "date-time"
-                },
-                {
-                    "type": "string",
-                    "format": "date",
-                    "subtype": "date"
-                },
-                {
-                    "type": "string",
-                    "format": "time",
-                    "subtype": "time"
-                }
-            ],
+            "schema": {
+                "description": "Any data type is allowed."
+            },
             "required": true
         },
         "y": {
             "description": "Second operand.",
-            "schema": [
-                {
-                    "type": "number"
-                },
-                {
-                    "type": "null"
-                },
-                {
-                    "type": "string",
-                    "format": "date-time",
-                    "subtype": "date-time"
-                },
-                {
-                    "type": "string",
-                    "format": "date",
-                    "subtype": "date"
-                },
-                {
-                    "type": "string",
-                    "format": "time",
-                    "subtype": "time"
-                }
-            ],
+            "schema": {
+                "description": "Any data type is allowed."
+            },
             "required": true
         }
     },
     "returns": {
-        "description": "`true` if `x` is strictly greater than `y` or `null` if any of the operands is `null`, otherwise `false`.",
+        "description": "`true` if `x` is strictly greater than `y` or `null` if any operand is `null`, otherwise `false`.",
         "schema": {
             "type": [
                 "boolean",
@@ -128,6 +88,13 @@
             "arguments": {
                 "x": true,
                 "y": 0
+            },
+            "returns": false
+        },
+        {
+            "arguments": {
+                "x": true,
+                "y": false
             },
             "returns": false
         }

--- a/gt.json
+++ b/gt.json
@@ -1,7 +1,7 @@
 {
     "id": "gt",
     "summary": "Greater than comparison",
-    "description": "Compares whether `x` is strictly greater than `y`.\n\n**Remarks:**\n\n* If any operand is `null`, the return value is `null`. If any operand is not a `number` or temporal string (`date`, `time` or `date-time`), the process returns `false`.\n* Temporal strings can *not* be compared based on their string representation due to the time zone / time-offset representations.",
+    "description": "Compares whether `x` is strictly greater than `y`.\n\n**Remarks:**\n\n* If any operand is `null`, the return value is `null`.\n* If any operand is an array or object, the return value is `false`.\n* If any operand is not a `number` or temporal string (`date`, `time` or `date-time`), the process returns `false`.\n* Temporal strings can *not* be compared based on their string representation due to the time zone / time-offset representations.",
     "categories": [
         "comparison"
     ],

--- a/gte.json
+++ b/gte.json
@@ -1,7 +1,7 @@
 {
     "id": "gte",
     "summary": "Greater than or equal to comparison",
-    "description": "Compares whether `x` is greater than or equal to `y`.\n\n**Remarks:**\n\n* If any of the operands is `null`, the return value is `null`.\n* Temporal strings can *not* be compared based on their string representation due to the time zone / time-offset representations.\n* Comparing strings is currently not supported, but is planned to be added in the future.",
+    "description": "Compares whether `x` is greater than or equal to `y`.\n\n**Remarks:**\n\n* If any operand is `null`, the return value is `null`. If the operands are not equal (see process ``eq()``) and any of them is not a `number` or temporal string (`date`, `time` or `date-time`), the process returns `false`.\n* Temporal strings can *not* be compared based on their string representation due to the time zone / time-offset representations.",
     "categories": [
         "comparison"
     ],
@@ -12,61 +12,21 @@
     "parameters": {
         "x": {
             "description": "First operand.",
-            "schema": [
-                {
-                    "type": "number"
-                },
-                {
-                    "type": "null"
-                },
-                {
-                    "type": "string",
-                    "format": "date-time",
-                    "subtype": "date-time"
-                },
-                {
-                    "type": "string",
-                    "format": "date",
-                    "subtype": "date"
-                },
-                {
-                    "type": "string",
-                    "format": "time",
-                    "subtype": "time"
-                }
-            ],
+            "schema": {
+                "description": "Any data type is allowed."
+            },
             "required": true
         },
         "y": {
             "description": "Second operand.",
-            "schema": [
-                {
-                    "type": "number"
-                },
-                {
-                    "type": "null"
-                },
-                {
-                    "type": "string",
-                    "format": "date-time",
-                    "subtype": "date-time"
-                },
-                {
-                    "type": "string",
-                    "format": "date",
-                    "subtype": "date"
-                },
-                {
-                    "type": "string",
-                    "format": "time",
-                    "subtype": "time"
-                }
-            ],
+            "schema": {
+                "description": "Any data type is allowed."
+            },
             "required": true
         }
     },
     "returns": {
-        "description": "`true` if `x` is greater than or equal to `y` or `null` if any of the operands is `null`, otherwise `false`.",
+        "description": "`true` if `x` is greater than or equal to `y`, `null` if any operand is `null`, otherwise `false`.",
         "schema": {
             "type": [
                 "boolean",
@@ -123,6 +83,13 @@
                 "y": "2018-01-01T12:00:00Z"
             },
             "returns": true
+        },
+        {
+            "arguments": {
+                "x": true,
+                "y": false
+            },
+            "returns": false
         }
     ]
 }

--- a/gte.json
+++ b/gte.json
@@ -1,7 +1,7 @@
 {
     "id": "gte",
     "summary": "Greater than or equal to comparison",
-    "description": "Compares whether `x` is greater than or equal to `y`.\n\n**Remarks:**\n\n* If any operand is `null`, the return value is `null`. If the operands are not equal (see process ``eq()``) and any of them is not a `number` or temporal string (`date`, `time` or `date-time`), the process returns `false`.\n* Temporal strings can *not* be compared based on their string representation due to the time zone / time-offset representations.",
+    "description": "Compares whether `x` is greater than or equal to `y`.\n\n**Remarks:**\n\n* If any operand is `null`, the return value is `null`.\n* If any operand is an array or object, the return value is `false`.\n* If the operands are not equal (see process ``eq()``) and any of them is not a `number` or temporal string (`date`, `time` or `date-time`), the process returns `false`.\n* Temporal strings can *not* be compared based on their string representation due to the time zone / time-offset representations.",
     "categories": [
         "comparison"
     ],
@@ -88,6 +88,13 @@
             "arguments": {
                 "x": true,
                 "y": false
+            },
+            "returns": false
+        },
+        {
+            "arguments": {
+                "x": [1,2,3],
+                "y": [1,2,3]
             },
             "returns": false
         }

--- a/lt.json
+++ b/lt.json
@@ -1,7 +1,7 @@
 {
     "id": "lt",
     "summary": "Less than comparison",
-    "description": "Compares whether `x` is strictly less than `y`.\n\n**Remarks:**\n\n* If any of the operands is `null`, the return value is `null`.\n* Temporal strings can *not* be compared based on their string representation due to the time zone / time-offset representations.\n* Comparing strings is currently not supported, but is planned to be added in the future.",
+    "description": "Compares whether `x` is strictly less than `y`.\n\n**Remarks:**\n\n* If any operand is `null`, the return value is `null`. If any operand is not a `number` or temporal string (`date`, `time` or `date-time`), the process returns `false`.\n* Temporal strings can *not* be compared based on their string representation due to the time zone / time-offset representations.",
     "categories": [
         "comparison"
     ],
@@ -12,61 +12,21 @@
     "parameters": {
         "x": {
             "description": "First operand.",
-            "schema": [
-                {
-                    "type": "number"
-                },
-                {
-                    "type": "null"
-                },
-                {
-                    "type": "string",
-                    "format": "date-time",
-                    "subtype": "date-time"
-                },
-                {
-                    "type": "string",
-                    "format": "date",
-                    "subtype": "date"
-                },
-                {
-                    "type": "string",
-                    "format": "time",
-                    "subtype": "time"
-                }
-            ],
+            "schema": {
+                "description": "Any data type is allowed."
+            },
             "required": true
         },
         "y": {
             "description": "Second operand.",
-            "schema": [
-                {
-                    "type": "number"
-                },
-                {
-                    "type": "null"
-                },
-                {
-                    "type": "string",
-                    "format": "date-time",
-                    "subtype": "date-time"
-                },
-                {
-                    "type": "string",
-                    "format": "date",
-                    "subtype": "date"
-                },
-                {
-                    "type": "string",
-                    "format": "time",
-                    "subtype": "time"
-                }
-            ],
+            "schema": {
+                "description": "Any data type is allowed."
+            },
             "required": true
         }
     },
     "returns": {
-        "description": "`true` if `x` is strictly less than `y`, `null` if any of the operands is `null`, otherwise `false`.",
+        "description": "`true` if `x` is strictly less than `y`, `null` if any operand is `null`, otherwise `false`.",
         "schema": {
             "type": [
                 "boolean",
@@ -127,6 +87,13 @@
         {
             "arguments": {
                 "x": 0,
+                "y": true
+            },
+            "returns": false
+        },
+        {
+            "arguments": {
+                "x": false,
                 "y": true
             },
             "returns": false

--- a/lt.json
+++ b/lt.json
@@ -1,7 +1,7 @@
 {
     "id": "lt",
     "summary": "Less than comparison",
-    "description": "Compares whether `x` is strictly less than `y`.\n\n**Remarks:**\n\n* If any operand is `null`, the return value is `null`. If any operand is not a `number` or temporal string (`date`, `time` or `date-time`), the process returns `false`.\n* Temporal strings can *not* be compared based on their string representation due to the time zone / time-offset representations.",
+    "description": "Compares whether `x` is strictly less than `y`.\n\n**Remarks:**\n\n* If any operand is `null`, the return value is `null`.\n* If any operand is an array or object, the return value is `false`.\n* If any operand is not a `number` or temporal string (`date`, `time` or `date-time`), the process returns `false`.\n* Temporal strings can *not* be compared based on their string representation due to the time zone / time-offset representations.",
     "categories": [
         "comparison"
     ],

--- a/lte.json
+++ b/lte.json
@@ -1,7 +1,7 @@
 {
     "id": "lte",
     "summary": "Less than or equal to comparison",
-    "description": "Compares whether `x` is less than or equal to `y`.\n\n**Remarks:**\n\n* If any operand is `null`, the return value is `null`. If the operands are not equal (see process ``eq()``) and any of them is not a `number` or temporal string (`date`, `time` or `date-time`), the process returns `false`.\n* Temporal strings can *not* be compared based on their string representation due to the time zone / time-offset representations.",
+    "description": "Compares whether `x` is less than or equal to `y`.\n\n**Remarks:**\n\n* If any operand is `null`, the return value is `null`.\n* If any operand is an array or object, the return value is `false`.\n* If the operands are not equal (see process ``eq()``) and any of them is not a `number` or temporal string (`date`, `time` or `date-time`), the process returns `false`.\n* Temporal strings can *not* be compared based on their string representation due to the time zone / time-offset representations.",
     "categories": [
         "comparison"
     ],
@@ -88,6 +88,13 @@
             "arguments": {
                 "x": false,
                 "y": true
+            },
+            "returns": false
+        },
+        {
+            "arguments": {
+                "x": [1,2,3],
+                "y": [1,2,3]
             },
             "returns": false
         }

--- a/lte.json
+++ b/lte.json
@@ -1,7 +1,7 @@
 {
     "id": "lte",
     "summary": "Less than or equal to comparison",
-    "description": "Compares whether `x` is less than or equal to `y`.\n\n**Remarks:**\n\n* If any of the operands is `null`, the return value is `null`.\n* Temporal strings can *not* be compared based on their string representation due to the time zone / time-offset representations.\n* Comparing strings is currently not supported, but is planned to be added in the future.",
+    "description": "Compares whether `x` is less than or equal to `y`.\n\n**Remarks:**\n\n* If any operand is `null`, the return value is `null`. If the operands are not equal (see process ``eq()``) and any of them is not a `number` or temporal string (`date`, `time` or `date-time`), the process returns `false`.\n* Temporal strings can *not* be compared based on their string representation due to the time zone / time-offset representations.",
     "categories": [
         "comparison"
     ],
@@ -12,61 +12,21 @@
     "parameters": {
         "x": {
             "description": "First operand.",
-            "schema": [
-                {
-                    "type": "number"
-                },
-                {
-                    "type": "null"
-                },
-                {
-                    "type": "string",
-                    "format": "date-time",
-                    "subtype": "date-time"
-                },
-                {
-                    "type": "string",
-                    "format": "date",
-                    "subtype": "date"
-                },
-                {
-                    "type": "string",
-                    "format": "time",
-                    "subtype": "time"
-                }
-            ],
+            "schema": {
+                "description": "Any data type is allowed."
+            },
             "required": true
         },
         "y": {
             "description": "Second operand.",
-            "schema": [
-                {
-                    "type": "number"
-                },
-                {
-                    "type": "null"
-                },
-                {
-                    "type": "string",
-                    "format": "date-time",
-                    "subtype": "date-time"
-                },
-                {
-                    "type": "string",
-                    "format": "date",
-                    "subtype": "date"
-                },
-                {
-                    "type": "string",
-                    "format": "time",
-                    "subtype": "time"
-                }
-            ],
+            "schema": {
+                "description": "Any data type is allowed."
+            },
             "required": true
         }
     },
     "returns": {
-        "description": "`true` if `x` is less than or equal to `y`, `null` if any of the operands is `null`, otherwise `false`.",
+        "description": "`true` if `x` is less than or equal to `y`, `null` if any operand is `null`, otherwise `false`.",
         "schema": {
             "type": [
                 "boolean",
@@ -123,6 +83,13 @@
                 "y": "2018-01-01T12:00:00Z"
             },
             "returns": true
+        },
+        {
+            "arguments": {
+                "x": false,
+                "y": true
+            },
+            "returns": false
         }
     ]
 }

--- a/neq.json
+++ b/neq.json
@@ -1,7 +1,7 @@
 {
     "id": "neq",
     "summary": "Not equal to comparison",
-    "description": "Compares whether `x` is *not* strictly equal to `y`. This process is an alias for: `not(eq(val1, val2))`.\n\n**Remarks:**\n\n* Data types MUST be checked strictly, for example a string with the content *1* is not equal to the number *1*. Nevertheless, an integer *1* is equal to a floating point number *1.0* as `integer` is a sub-type of `number`.\n* If any operand is `null`, the return value is `null`.\n* Strings are expected to be encoded in UTF-8 by default.\n* Temporal strings MUST be compared differently than other strings and MUST NOT be compared based on their string representation due to different possible representations. For example, the UTC time zone representation `Z` has the same meaning as `+00:00`.",
+    "description": "Compares whether `x` is *not* strictly equal to `y`. This process is an alias for: `not(eq(val1, val2))`.\n\n**Remarks:**\n\n* Data types MUST be checked strictly, for example a string with the content *1* is not equal to the number *1*. Nevertheless, an integer *1* is equal to a floating point number *1.0* as `integer` is a sub-type of `number`.\n* If any operand is `null`, the return value is `null`.\n* If any operand is an array or object, the return value is `false`.\n* Strings are expected to be encoded in UTF-8 by default.\n* Temporal strings MUST be compared differently than other strings and MUST NOT be compared based on their string representation due to different possible representations. For example, the UTC time zone representation `Z` has the same meaning as `+00:00`.",
     "categories": [
         "texts",
         "comparison"
@@ -150,6 +150,13 @@
             "arguments": {
                 "x": "2018-01-01T00:00:00Z",
                 "y": "2018-01-01T01:00:00+01:00"
+            },
+            "returns": false
+        },
+        {
+            "arguments": {
+                "x": [1,2,3],
+                "y": [1,2,3]
             },
             "returns": false
         }

--- a/neq.json
+++ b/neq.json
@@ -1,7 +1,7 @@
 {
     "id": "neq",
     "summary": "Not equal to comparison",
-    "description": "Compares whether `x` is *not* strictly equal to `y`. This process is an alias for: `not(eq(val1, val2))`.\n\n**Remarks:**\n\n* Data types MUST be checked strictly, for example a string with the content *1* is not equal to the number *1*. Nevertheless, an integer *1* is equal to a floating point number *1.0* as `integer` is a sub-type of `number`.\n* If any of the operands is `null`, the return value is `null`.\n* Strings are expected to be encoded in UTF-8 by default.\n* Temporal strings MUST be compared differently than other strings and MUST NOT be compared based on their string representation due to different possible representations. For example, the UTC time zone representation `Z` has the same meaning as `+00:00`.",
+    "description": "Compares whether `x` is *not* strictly equal to `y`. This process is an alias for: `not(eq(val1, val2))`.\n\n**Remarks:**\n\n* Data types MUST be checked strictly, for example a string with the content *1* is not equal to the number *1*. Nevertheless, an integer *1* is equal to a floating point number *1.0* as `integer` is a sub-type of `number`.\n* If any operand is `null`, the return value is `null`.\n* Strings are expected to be encoded in UTF-8 by default.\n* Temporal strings MUST be compared differently than other strings and MUST NOT be compared based on their string representation due to different possible representations. For example, the UTC time zone representation `Z` has the same meaning as `+00:00`.",
     "categories": [
         "texts",
         "comparison"
@@ -15,68 +15,16 @@
     "parameters": {
         "x": {
             "description": "First operand.",
-            "schema": [
-                {
-                    "type": "number"
-                },
-                {
-                    "type": "boolean"
-                },
-                {
-                    "type": "null"
-                },
-                {
-                    "type": "string"
-                },
-                {
-                    "type": "string",
-                    "format": "date-time",
-                    "subtype": "date-time"
-                },
-                {
-                    "type": "string",
-                    "format": "date",
-                    "subtype": "date"
-                },
-                {
-                    "type": "string",
-                    "format": "time",
-                    "subtype": "time"
-                }
-            ],
+            "schema": {
+                "description": "Any data type is allowed."
+            },
             "required": true
         },
         "y": {
             "description": "Second operand.",
-            "schema": [
-                {
-                    "type": "number"
-                },
-                {
-                    "type": "boolean"
-                },
-                {
-                    "type": "null"
-                },
-                {
-                    "type": "string"
-                },
-                {
-                    "type": "string",
-                    "format": "date-time",
-                    "subtype": "date-time"
-                },
-                {
-                    "type": "string",
-                    "format": "date",
-                    "subtype": "date"
-                },
-                {
-                    "type": "string",
-                    "format": "time",
-                    "subtype": "time"
-                }
-            ],
+            "schema": {
+                "description": "Any data type is allowed."
+            },
             "required": true
         },
         "delta": {
@@ -98,7 +46,7 @@
         }
     },
     "returns": {
-        "description": "Returns `true` if `x` is *not* equal to `y`, `null` if any of the operands is `null`, otherwise `false`.",
+        "description": "Returns `true` if `x` is *not* equal to `y`, `null` if any operand is `null`, otherwise `false`.",
         "schema": {
             "type": [
                 "boolean",

--- a/text_begins.json
+++ b/text_begins.json
@@ -1,7 +1,7 @@
 {
     "id": "text_begins",
     "summary": "Text begins with another text",
-    "description": "Checks whether the text (also known as *string*) specified for `data` contains the text specified for `pattern` at the very beginning. Both are expected to be encoded in UTF-8 by default. Regular expressions are not supported.",
+    "description": "Checks whether the text (also known as *string*) specified for `data` contains the text specified for `pattern` at the beginning. Both are expected to be encoded in UTF-8 by default. The no-data value `null` is passed through and therefore gets propagated.",
     "categories": [
         "texts",
         "comparison"
@@ -15,12 +15,15 @@
         "data": {
             "description": "Text in which to find something at the beginning.",
             "schema": {
-                "type": "string"
+                "type": [
+                    "string",
+                    "null"
+                ]
             },
             "required": true
         },
         "pattern": {
-            "description": "Text to find at the beginning of `data`.",
+            "description": "Text to find at the beginning of `data`. Regular expressions are not supported.",
             "schema": {
                 "type": "string"
             },
@@ -37,7 +40,10 @@
     "returns": {
         "description": "`true` if `data` begins with `pattern`, false` otherwise.",
         "schema": {
-            "type": "boolean"
+            "type": [
+                "boolean",
+                "null"
+            ]
         }
     },
     "examples": [
@@ -77,6 +83,13 @@
                 "case_sensitive": false
             },
             "returns": true
+        },
+        {
+            "arguments": {
+                "data": null,
+                "pattern": "null"
+            },
+            "returns": null
         }
     ]
 }

--- a/text_contains.json
+++ b/text_contains.json
@@ -1,7 +1,7 @@
 {
     "id": "text_contains",
     "summary": "Text contains another text",
-    "description": "Checks whether the text (also known as *string*) specified for `data` contains the text specified for `pattern`. Both are expected to be encoded in UTF-8 by default. Regular expressions are not supported.",
+    "description": "Checks whether the text (also known as *string*) specified for `data` contains the text specified for `pattern`. Both are expected to be encoded in UTF-8 by default. The no-data value `null` is passed through and therefore gets propagated.",
     "categories": [
         "texts",
         "comparison"
@@ -15,12 +15,15 @@
         "data": {
             "description": "Text in which to find something in.",
             "schema": {
-                "type": "string"
+                "type": [
+                    "string",
+                    "null"
+                ]
             },
             "required": true
         },
         "pattern": {
-            "description": "Text to find in `data`.",
+            "description": "Text to find in `data`. Regular expressions are not supported.",
             "schema": {
                 "type": "string"
             },
@@ -37,7 +40,10 @@
     "returns": {
         "description": "`true` if `data` contains the `pattern`, false` otherwise.",
         "schema": {
-            "type": "boolean"
+            "type": [
+                "boolean",
+                "null"
+            ]
         }
     },
     "examples": [
@@ -77,6 +83,13 @@
                 "case_sensitive": false
             },
             "returns": true
+        },
+        {
+            "arguments": {
+                "data": null,
+                "pattern": "null"
+            },
+            "returns": null
         }
     ]
 }

--- a/text_ends.json
+++ b/text_ends.json
@@ -1,7 +1,7 @@
 {
     "id": "text_ends",
     "summary": "Text ends with another text",
-    "description": "Checks whether the text (also known as *string*) specified for `data` contains the text specified for `pattern` at the very end. Both are expected to be encoded in UTF-8 by default. Regular expressions are not supported.",
+    "description": "Checks whether the text (also known as *string*) specified for `data` contains the text specified for `pattern` at the end. Both are expected to be encoded in UTF-8 by default. The no-data value `null` is passed through and therefore gets propagated.",
     "categories": [
         "texts",
         "comparison"
@@ -15,12 +15,15 @@
         "data": {
             "description": "Text in which to find something at the end.",
             "schema": {
-                "type": "string"
+                "type": [
+                    "string",
+                    "null"
+                ]
             },
             "required": true
         },
         "pattern": {
-            "description": "Text to find at the end of `data`.",
+            "description": "Text to find at the end of `data`. Regular expressions are not supported.",
             "schema": {
                 "type": "string"
             },
@@ -37,7 +40,10 @@
     "returns": {
         "description": "`true` if `data` ends with `pattern`, false` otherwise.",
         "schema": {
-            "type": "boolean"
+            "type": [
+                "boolean",
+                "null"
+            ]
         }
     },
     "examples": [
@@ -77,6 +83,13 @@
                 "case_sensitive": false
             },
             "returns": true
+        },
+        {
+            "arguments": {
+                "data": null,
+                "pattern": "null"
+            },
+            "returns": null
         }
     ]
 }


### PR DESCRIPTION
Changes:
- Comparison processes `eq`, `gt`, `gte`, `lt`, `lte`, `neq` and `between` accept all data types as input for the operands.
- `text_begins`, `text_contains`, `text_ends`: `null` values are supported and get passed through.
- Fix: `between` may return a `null` value.
- Several clarifications

I think all changes are quite straightforward. The thing to debate is probably whether arrays and objects should be comparable or always return false?

Main reason for the changes was the absence of some data types from some of the comparison, especially booleans.