### PR TITLE
Cleaning up after recent changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `text_begins`, `text_contains`, `text_ends`: `null` values are supported and get passed through.
 
 ### Deprecated
-- `filter_bbox`, `load_collection`, `resample_spatial`: PROJ definitions are deprecated in favor of EPSG codes, WKT2 and PROJJSON. [#58](https://github.com/Open-EO/openeo-processes/issues/58)
+- `filter_bbox`, `load_collection`, `resample_spatial`: PROJ definitions are deprecated in favor of EPSG codes and WKT2. [#58](https://github.com/Open-EO/openeo-processes/issues/58)
 
 ### Removed
 - The following processes don't support `ignore_nodata` any longer: `and`, `divide`, `multiply`, `or`, `subtract`, `xor`. [#85](https://github.com/Open-EO/openeo-processes/issues/85)

--- a/add_dimension.json
+++ b/add_dimension.json
@@ -32,21 +32,6 @@
                 },
                 {
                     "type": "string"
-                },
-                {
-                    "type": "string",
-                    "format": "date-time",
-                    "subtype": "date-time"
-                },
-                {
-                    "type": "string",
-                    "format": "date",
-                    "subtype": "date"
-                },
-                {
-                    "type": "string",
-                    "format": "time",
-                    "subtype": "time"
                 }
             ],
             "required": true

--- a/aggregate_temporal.json
+++ b/aggregate_temporal.json
@@ -110,19 +110,7 @@
                 "items": {
                     "anyOf": [
                         {
-                            "type": "string",
-                            "format": "date-time",
-                            "subtype": "date-time"
-                        },
-                        {
-                            "type": "string",
-                            "format": "date",
-                            "subtype": "date"
-                        },
-                        {
-                            "type": "string",
-                            "format": "time",
-                            "subtype": "time"
+                            "type": "number"
                         },
                         {
                             "type": "string"

--- a/filter_bbox.json
+++ b/filter_bbox.json
@@ -62,7 +62,7 @@
                         "default": null
                     },
                     "crs": {
-                        "description": "Coordinate reference system of the extent, specified as as [EPSG code](http://www.epsg-registry.org/), [WKT2 (ISO 19162) string](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html), [PROJJSON](https://proj.org/projjson.html) or [PROJ definition (deprecated)](https://proj.org/usage/quickstart.html). Defaults to `4326` (EPSG code 4326) unless the client explicitly requests a different coordinate reference system.",
+                        "description": "Coordinate reference system of the extent, specified as as [EPSG code](http://www.epsg-registry.org/), [WKT2 (ISO 19162) string](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html) or [PROJ definition (deprecated)](https://proj.org/usage/quickstart.html). Defaults to `4326` (EPSG code 4326) unless the client explicitly requests a different coordinate reference system.",
                         "anyOf": [
                             {
                                 "title": "EPSG Code",
@@ -82,11 +82,6 @@
                                 "type": "string",
                                 "subtype": "proj-definition",
                                 "deprecated": true
-                            },
-                            {
-                                "title": "PROJJSON",
-                                "type": "object",
-                                "subtype": "projjson-definition"
                             }
                         ],
                         "default": 4326

--- a/filter_labels.json
+++ b/filter_labels.json
@@ -27,9 +27,14 @@
                         "name": "value",
                         "description": "A single dimension label to compare against. The data type of the parameter depends on the dimension labels stored for the dimension.",
                         "required": true,
-                        "schema": {
-                            "description": "Any data type."
-                        }
+                        "schema": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ]
                     }
                 ]
             },

--- a/labels.json
+++ b/labels.json
@@ -29,7 +29,14 @@
         "schema": {
             "type": "array",
             "items": {
-                "type": "string"
+                "anyOf": [
+                    {
+                        "type": "number"
+                    },
+                    {
+                        "type": "string"
+                    }
+                ]
             }
         }
     }

--- a/load_collection.json
+++ b/load_collection.json
@@ -65,7 +65,7 @@
                             "default": null
                         },
                         "crs": {
-                            "description": "Coordinate reference system of the extent, specified as as [EPSG code](http://www.epsg-registry.org/), [WKT2 (ISO 19162) string](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html), [PROJJSON](https://proj.org/projjson.html) or [PROJ definition (deprecated)](https://proj.org/usage/quickstart.html). Defaults to `4326` (EPSG code 4326) unless the client explicitly requests a different coordinate reference system.",
+                            "description": "Coordinate reference system of the extent, specified as as [EPSG code](http://www.epsg-registry.org/), [WKT2 (ISO 19162) string](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html) or [PROJ definition (deprecated)](https://proj.org/usage/quickstart.html). Defaults to `4326` (EPSG code 4326) unless the client explicitly requests a different coordinate reference system.",
                             "anyOf": [
                                 {
                                     "title": "EPSG Code",
@@ -85,11 +85,6 @@
                                     "type": "string",
                                     "subtype": "proj-definition",
                                     "deprecated": true
-                                },
-                                {
-                                    "title": "PROJJSON",
-                                    "type": "object",
-                                    "subtype": "projjson-definition"
                                 }
                             ],
                             "default": 4326

--- a/rename_dimension.json
+++ b/rename_dimension.json
@@ -16,7 +16,7 @@
             "required": true
         },
         {
-            "name": "old",
+            "name": "source",
             "description": "The current name of the dimension. Fails with a `DimensionNotAvailable` error if the specified dimension does not exist.",
             "schema": {
                 "type": "string"
@@ -24,7 +24,7 @@
             "required": true
         },
         {
-            "name": "new",
+            "name": "target",
             "description": "A new Name for the dimension. Fails with a `DimensionExists` error if a dimension with the specified name exists.",
             "schema": {
                 "type": "string"

--- a/rename_labels.json
+++ b/rename_labels.json
@@ -1,7 +1,7 @@
 {
     "id": "rename_labels",
     "summary": "Rename dimension labels",
-    "description": "Renames the labels of a dimension in the data cube. Doesn't change the order of the labels and the corresponding data.",
+    "description": "Renames the labels of the specified dimension in the data cube from `source` to `target`.\n\nIf the array for the source labels is empty (the default), the dimension labels are expected to be enumerated with zero-based numbering (0,1,2,3,...) so that the dimension labels directly map to the indices of the array specified for the parameter `target`. If the dimension labels are not enumerated and the `target` parameter is not specified, a `LabelsNotEnumerated` is thrown. The number of source and target labels must be equal, otherwise the error `LabelMismatch` is thrown.\n\nThis process doesn't change the order of the labels and their corresponding data.",
     "categories": [
         "cubes"
     ],
@@ -24,23 +24,40 @@
             "required": true
         },
         {
-            "name": "labels",
-            "description": "The new names for the labels.\n\nIf an **array** is passed, the dimension labels in the data cube are expected to be enumerated with zero-based numbering (0,1,2,3,...) so that the dimension labels map to the array indices and get replaced. If the dimension labels are not enumerated, a `LabelsNotEnumerated` is thrown. The number of dimension labels must be equal to the number of array elements, otherwise the error `LabelMismatch` is thrown.\n\nIf an **object** is passed, the object defines an unsorted and potentially incomplete mapping of the source dimension labels to the target dimension labels. If one of the source dimension labels doesn't exist, a `LabelNotAvailable` error is thrown. If a target dimension label already exists in the data cube, a `LabelExists` error is thrown.",
-            "schema": [
-                {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
+            "name": "target",
+            "description": "The new names for the labels. The dimension labels in the data cube are expected to be enumerated, if the parameter `target` is not specified. If a target dimension label already exists in the data cube, a `LabelExists` error is thrown.",
+            "schema": {
+                "type": "array",
+                "items": {
+                    "anyOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
                 }
-            ],
+            },
             "required": true
+        },
+        {
+            "name": "source",
+            "description": "The names of the labels as they are currently in the data cube. The array defines an unsorted and potentially incomplete list of labels that should be renamed to the names available in the corresponding array elements in the parameter `target`. If one of the source dimension labels doesn't exist, a `LabelNotAvailable` error is thrown. By default, the array is empty so that the dimension labels in the data cube are expected to be enumerated.",
+            "schema": {
+                "type": "array",
+                "items": {
+                    "anyOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                }
+            },
+            "default": []
         }
     ],
     "returns": {
@@ -55,13 +72,13 @@
             "message": "The dimension labels are not enumerated."
         },
         "LabelMismatch": {
-            "message": "The number of labels specified doesn't match the actual number of labels."
+            "message": "The number of labels in the parameters `source` and `target` don't match."
         },
         "LabelNotAvailable": {
             "message": "A label with the specified name does not exist."
         },
         "LabelExists": {
-            "message": "A label with the specified name already exists."
+            "message": "A label with the specified name exists."
         }
     },
     "examples": [
@@ -90,11 +107,16 @@
                             "from_node": "loadco1"
                         },
                         "dimension": "bands",
-                        "labels": {
-                            "B1": "red",
-                            "B2": "green",
-                            "B3": "blue"
-                        }
+                        "source": [
+                            "B1",
+                            "B2",
+                            "B3"
+                        ],
+                        "target": [
+                            "red",
+                            "green",
+                            "blue"
+                        ]
                     },
                     "result": true
                 }
@@ -142,7 +164,7 @@
                             "from_node": "reduce1"
                         },
                         "dimension": "bands",
-                        "labels": [
+                        "target": [
                             "min",
                             "max"
                         ]

--- a/resample_spatial.json
+++ b/resample_spatial.json
@@ -40,7 +40,7 @@
         },
         {
             "name": "projection",
-            "description": "Warps the data cube to the target projection, specified as as [EPSG code](http://www.epsg-registry.org/), [WKT2 (ISO 19162) string](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html), [PROJJSON](https://proj.org/projjson.html) or [PROJ definition (deprecated)](https://proj.org/usage/quickstart.html). By default (`null`), the projection is not changed.",
+            "description": "Warps the data cube to the target projection, specified as as [EPSG code](http://www.epsg-registry.org/), [WKT2 (ISO 19162) string](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html), [PROJ definition (deprecated)](https://proj.org/usage/quickstart.html). By default (`null`), the projection is not changed.",
             "schema": [
                 {
                     "title": "EPSG Code",
@@ -60,11 +60,6 @@
                     "type": "string",
                     "subtype": "proj-definition",
                     "deprecated": true
-                },
-                {
-                    "title": "PROJJSON",
-                    "type": "object",
-                    "subtype": "projjson-definition"
                 },
                 {
                     "title": "Don't change projection",

--- a/tests/processes.test.js
+++ b/tests/processes.test.js
@@ -40,7 +40,6 @@ var subtypes = {
 	'process-graph-id': {type: 'string'},
 	'process-graph-variables': {type: 'object'},
 	'proj-definition': {type: 'string'},
-	'projjson-definition': {type: 'object'},
 	'raster-cube': {type: 'object'},
 	'temporal-interval': {type: 'array'},
 	'temporal-intervals': {type: 'array'},

--- a/tests/processes.test.js
+++ b/tests/processes.test.js
@@ -102,8 +102,19 @@ jsv.addKeyword("parameters", {
 					// Any type
 				},
 				schema: {
-					type: "object"
-					// ToDo: Check Schema
+					oneOf: [
+						{
+							type: "object",
+							// ToDo: Check Schema
+						},
+						{
+							type: "array",
+							items: {
+								type: "object"
+								// ToDo: Check Schema
+							}
+						}
+					]
 				}
 			}
 		}


### PR DESCRIPTION
Changes:
1. Remove support for PROJJSON as CRS. Now that we use CRS as dimension, it would complicate the label handling due to PROJJSON not being a number or string.
2. Don't explicitly specify the subtypes if a general type has been specified. For example, temporal strings are always allowed if strings are allowed thus it's not required to mention them explicitly in schemas. Clients should allow all subtypes for the general types to be passed.
3. Make sure labels are always strings or numbers.

Related PR in API: https://github.com/Open-EO/openeo-api/pull/254
Related commit in openeo.org: https://github.com/Open-EO/openeo.org/commit/bf9e8271c5df11a5ea46d5e3c6300df7dd9ad8e2