### PR TITLE
`any` and `all`: Renamed parameter `values` to `data`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Folder with examples (`examples/`). [#136](https://github.com/Open-EO/openeo-processes/issues/136)
 
 ### Changed
+- `any` and `all`: Renamed parameter `values` to `data`. [#147](https://github.com/Open-EO/openeo-processes/issues/147)
 - Examples adapted to latest API version for `aggregate_temporal`, `array_contains`, `array_find`, `filter_labels`, `load_collection` and `rename_labels`. [#136](https://github.com/Open-EO/openeo-processes/issues/136), [API#285](https://github.com/Open-EO/openeo-api/issues/285)
 
 ### Removed

--- a/all.json
+++ b/all.json
@@ -1,14 +1,14 @@
 {
     "id": "all",
     "summary": "Are all of the values true?",
-    "description": "Checks if **all** of the values are true. Evaluates all values from the first to the last element and stops once the outcome is unambiguous.\n\nIf only one value is given, the process evaluates to the given value. If no value is given (i.e. the array is empty) the process returns `null`.\n\nBy default all no-data values are ignored so that the process returns `null` if all values are no-data, `true` if all other values are true and `false` otherwise. Setting the `ignore_nodata` flag to `false` considers no-data values so that `null` is a valid logical object. If a component is `null`, the result will be `null` if the outcome is ambiguous. See the following truth table:\n\n```\n      || null  | false | true\n----- || ----- | ----- | -----\nnull  || null  | false | null\nfalse || false | false | false\ntrue  || null  | false | true\n```",
+    "description": "Checks if **all** of the values in `data` are true. Evaluates all values from the first to the last element and stops once the outcome is unambiguous.\n\nIf only one value is given, the process evaluates to the given value. If no value is given (i.e. the array is empty) the process returns `null`.\n\nBy default all no-data values are ignored so that the process returns `null` if all values are no-data, `true` if all other values are true and `false` otherwise. Setting the `ignore_nodata` flag to `false` considers no-data values so that `null` is a valid logical object. If a component is `null`, the result will be `null` if the outcome is ambiguous. See the following truth table:\n\n```\n      || null  | false | true\n----- || ----- | ----- | -----\nnull  || null  | false | null\nfalse || false | false | false\ntrue  || null  | false | true\n```",
     "categories": [
         "logic",
         "reducer"
     ],
     "parameters": [
         {
-            "name": "values",
+            "name": "data",
             "description": "A set of boolean values.",
             "schema": {
                 "type": "array",
@@ -42,7 +42,7 @@
     "examples": [
         {
             "arguments": {
-                "values": [
+                "data": [
                     false,
                     null
                 ]
@@ -51,7 +51,7 @@
         },
         {
             "arguments": {
-                "values": [
+                "data": [
                     true,
                     null
                 ]
@@ -60,7 +60,7 @@
         },
         {
             "arguments": {
-                "values": [
+                "data": [
                     false,
                     null
                 ],
@@ -70,7 +70,7 @@
         },
         {
             "arguments": {
-                "values": [
+                "data": [
                     true,
                     null
                 ],
@@ -80,7 +80,7 @@
         },
         {
             "arguments": {
-                "values": [
+                "data": [
                     true,
                     false,
                     true,
@@ -91,7 +91,7 @@
         },
         {
             "arguments": {
-                "values": [
+                "data": [
                     true,
                     false
                 ]
@@ -100,7 +100,7 @@
         },
         {
             "arguments": {
-                "values": [
+                "data": [
                     true,
                     true
                 ]
@@ -109,7 +109,7 @@
         },
         {
             "arguments": {
-                "values": [
+                "data": [
                     true
                 ]
             },
@@ -117,7 +117,7 @@
         },
         {
             "arguments": {
-                "values": [
+                "data": [
                     null
                 ],
                 "ignore_nodata": false
@@ -126,7 +126,7 @@
         },
         {
             "arguments": {
-                "values": []
+                "data": []
             },
             "returns": null
         }

--- a/any.json
+++ b/any.json
@@ -1,14 +1,14 @@
 {
     "id": "any",
     "summary": "Is at least one value true?",
-    "description": "Checks if **any** (i.e. at least one) value is `true`. Evaluates all values from the first to the last element and stops once the outcome is unambiguous.\n\nIf only one value is given, the process evaluates to the given value. If no value is given (i.e. the array is empty) the process returns `null`.\n\nBy default all no-data values are ignored so that the process returns `null` if all values are no-data, `true` if at least one of the other values is true and `false` otherwise. Setting the `ignore_nodata` flag to `false` considers no-data values so that `null` is a valid logical object. If a component is `null`, the result will be `null` if the outcome is ambiguous. See the following truth table:\n\n```\n      || null | false | true\n----- || ---- | ----- | ----\nnull  || null | null  | true\nfalse || null | false | true\ntrue  || true | true  | true\n```",
+    "description": "Checks if **any** (i.e. at least one) value in `data` is `true`. Evaluates all values from the first to the last element and stops once the outcome is unambiguous.\n\nIf only one value is given, the process evaluates to the given value. If no value is given (i.e. the array is empty) the process returns `null`.\n\nBy default all no-data values are ignored so that the process returns `null` if all values are no-data, `true` if at least one of the other values is true and `false` otherwise. Setting the `ignore_nodata` flag to `false` considers no-data values so that `null` is a valid logical object. If a component is `null`, the result will be `null` if the outcome is ambiguous. See the following truth table:\n\n```\n      || null | false | true\n----- || ---- | ----- | ----\nnull  || null | null  | true\nfalse || null | false | true\ntrue  || true | true  | true\n```",
     "categories": [
         "logic",
         "reducer"
     ],
     "parameters": [
         {
-            "name": "values",
+            "name": "data",
             "description": "A set of boolean values.",
             "schema": {
                 "type": "array",
@@ -42,7 +42,7 @@
     "examples": [
         {
             "arguments": {
-                "values": [
+                "data": [
                     false,
                     null
                 ]
@@ -51,7 +51,7 @@
         },
         {
             "arguments": {
-                "values": [
+                "data": [
                     true,
                     null
                 ]
@@ -60,7 +60,7 @@
         },
         {
             "arguments": {
-                "values": [
+                "data": [
                     false,
                     null
                 ],
@@ -70,7 +70,7 @@
         },
         {
             "arguments": {
-                "values": [
+                "data": [
                     true,
                     null
                 ],
@@ -80,7 +80,7 @@
         },
         {
             "arguments": {
-                "values": [
+                "data": [
                     true,
                     false,
                     true,
@@ -91,7 +91,7 @@
         },
         {
             "arguments": {
-                "values": [
+                "data": [
                     true,
                     false
                 ]
@@ -100,7 +100,7 @@
         },
         {
             "arguments": {
-                "values": [
+                "data": [
                     false,
                     false
                 ]
@@ -109,7 +109,7 @@
         },
         {
             "arguments": {
-                "values": [
+                "data": [
                     true
                 ]
             },
@@ -117,7 +117,7 @@
         },
         {
             "arguments": {
-                "values": [
+                "data": [
                     null
                 ],
                 "ignore_nodata": false
@@ -126,7 +126,7 @@
         },
         {
             "arguments": {
-                "values": []
+                "data": []
             },
             "returns": null
         }


### PR DESCRIPTION
see #147