### PR TITLE
Add `constant` process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `aggregate_temporal_period`
     - `anomaly`
     - `climatological_normal`
+    - `constant`
 - Folder with examples (`examples/`). [#136](https://github.com/Open-EO/openeo-processes/issues/136)
 
 ### Changed

--- a/constant.json
+++ b/constant.json
@@ -1,7 +1,7 @@
 {
     "id": "constant",
     "summary": "Define a constant value",
-    "description": "Define a constant value that can be reused in multiple places of the process graph",
+    "description": "Defines a constant value that can be reused in multiple places of a process.",
     "categories": [
         "math > constants"
     ],
@@ -10,46 +10,14 @@
             "name": "x",
             "description": "The value of the constant.",
             "schema": {
-                "type": "number"
+                "description": "Any data type."
             }
         }
     ],
     "returns": {
         "description": "The value of the constant.",
         "schema": {
-            "type": "number"
+            "description": "Any data type."
         }
-    },
-    "examples": [
-        {
-            "title": "Reuse of a constant value",
-            "process_graph": {
-                "margin1": {
-                    "process_id": "constant",
-                    "arguments": {
-                        "x": 0.1
-                    }
-                },
-                "west1": {
-                    "process_id": "subtract",
-                    "arguments": {
-                        "x": 3.5,
-                        "y": {
-                            "from_node": "margin"
-                        }
-                    }
-                },
-                "east1": {
-                    "process_id": "add",
-                    "arguments": {
-                        "x": 3.8,
-                        "y": {
-                            "from_node": "margin"
-                        }
-                    }
-                }
-            }
-        }
-    ],
-    "links": []
+    }
 }

--- a/constant.json
+++ b/constant.json
@@ -1,0 +1,55 @@
+{
+    "id": "constant",
+    "summary": "Define a constant value",
+    "description": "Define a constant value that can be reused in multiple places of the process graph",
+    "categories": [
+        "math > constants"
+    ],
+    "parameters": [
+        {
+            "name": "x",
+            "description": "The value of the constant.",
+            "schema": {
+                "type": "number"
+            }
+        }
+    ],
+    "returns": {
+        "description": "The value of the constant.",
+        "schema": {
+            "type": "number"
+        }
+    },
+    "examples": [
+        {
+            "title": "Reuse of a constant value",
+            "process_graph": {
+                "margin1": {
+                    "process_id": "constant",
+                    "arguments": {
+                        "x": 0.1
+                    }
+                },
+                "west1": {
+                    "process_id": "subtract",
+                    "arguments": {
+                        "x": 3.5,
+                        "y": {
+                            "from_node": "margin"
+                        }
+                    }
+                },
+                "east1": {
+                    "process_id": "add",
+                    "arguments": {
+                        "x": 3.8,
+                        "y": {
+                            "from_node": "margin"
+                        }
+                    }
+                }
+            }
+        }
+    ],
+    "links": []
+}


### PR DESCRIPTION
While working on support of user-defined processes it felt  that a `constant` process could be handy to avoid too much hardcoding of predefined values. With the `constant` process, you introduce a constant value node in the process graph, that you can reuse with `from_node`, instead of having to copy-paste that value all over the place. For standard openEO usage that is probably not necessary as the client probably hides that away, but for handcrafted user-defined processes it might be valuable.

Basic usage example:
```
                "margin1": {
                    "process_id": "constant",
                    "arguments": {
                        "x": 0.1
                    }
                },
                "west1": {
                    "process_id": "subtract",
                    "arguments": {
                        "x": 3.5,
                        "y": {
                            "from_node": "margin"
                        }
                    }
                },
                "east1": {
                    "process_id": "add",
                    "arguments": {
                        "x": 3.8,
                        "y": {
                            "from_node": "margin"
                        }
                    }
                }

```