### PR TITLE
`mean`: add process graph, clarify null arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `anomaly`
     - `climatological_normal`
     - `constant`
+- Process graphs added to:
+    - `mean`
 - Folder with examples (`examples/`). [#136](https://github.com/Open-EO/openeo-processes/issues/136)
 
 ### Changed
@@ -29,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `aggregate_temporal`: Fixed outdated message for exception `TooManyDimensions`.
 - `clip`: Fixed examples.
 - `resample_*`: Clarified behaviour.
+- `mean`: Clarify behavior for arrays with `null`-values only.
 
 ## 1.0.0-rc.1 - 2020-01-31
 

--- a/mean.json
+++ b/mean.json
@@ -115,7 +115,7 @@
                     "from_parameter": "data"
                 },
                 "condition": {
-                    "from_parameter": "count_condition"
+                    "from_node": "count_condition"
                 }
             }
         },

--- a/mean.json
+++ b/mean.json
@@ -9,7 +9,7 @@
     "parameters": [
         {
             "name": "data",
-            "description": "An array of numbers. An empty array resolves always with `null`.",
+            "description": "An array of numbers. An array without non-`null` elements resolves always with `null`.",
             "schema": {
                 "type": "array",
                 "items": {
@@ -78,6 +78,16 @@
                 "data": []
             },
             "returns": null
+        },
+        {
+            "description": "The input array has only `null` elements: return `null`.",
+            "arguments": {
+                "data": [
+                    null,
+                    null
+                ]
+            },
+            "returns": null
         }
     ],
     "links": [
@@ -86,5 +96,71 @@
             "href": "http://mathworld.wolfram.com/ArithmeticMean.html",
             "title": "Arithmetic mean explained by Wolfram MathWorld"
         }
-    ]
+    ],
+    "process_graph": {
+        "count_condition": {
+            "process_id": "if",
+            "arguments": {
+                "value": {
+                    "from_parameter": "ignore_nodata"
+                },
+                "accept": null,
+                "reject": true
+            }
+        },
+        "count": {
+            "process_id": "count",
+            "arguments": {
+                "data": {
+                    "from_parameter": "data"
+                },
+                "condition": {
+                    "from_parameter": "count_condition"
+                }
+            }
+        },
+        "sum": {
+            "process_id": "sum",
+            "arguments": {
+                "data": {
+                    "from_parameter": "data"
+                },
+                "ignore_nodata": {
+                    "from_parameter": "ignore_nodata"
+                }
+            }
+        },
+        "divide": {
+            "process_id": "divide",
+            "arguments": {
+                "x": {
+                    "from_node": "sum"
+                },
+                "y": {
+                    "from_node": "count"
+                }
+            }
+        },
+        "neq": {
+            "process_id": "neq",
+            "arguments": {
+                "x": {
+                    "from_node": "count"
+                },
+                "y": 0
+            }
+        },
+        "if": {
+            "process_id": "if",
+            "arguments": {
+                "value": {
+                    "from_node": "neq"
+                },
+                "accept": {
+                    "from_node": "divide"
+                }
+            },
+            "result": true
+        }
+    }
 }


### PR DESCRIPTION
Two changes I'd like to get some reviews for:
1. Add a process graph as "alias" #137 - did I miss anything?
    ![image](https://user-images.githubusercontent.com/8262166/86015563-05f7c600-ba22-11ea-8c31-7975c1eaf4d6.png)
    Especially wondering about whether sum and divide are actually called/executed for an an empty array as this would lead to a DivisionByZero exception although it strictly shouldn't throw.
2. Clarify how arrays with only null values are handled. That came up when implementing the alias. Does this work for all?