### PR TITLE
Issue #177: add exceptions to save_result and load_uploaded_files

### DIFF
--- a/load_uploaded_files.json
+++ b/load_uploaded_files.json
@@ -44,5 +44,19 @@
             "type": "object",
             "subtype": "raster-cube"
         }
+    },
+    "exceptions": {
+        "FormatUnsupported": {
+            "message": "Input format is not supported."
+        },
+        "FormatOptionRequired": {
+            "message": "Format option '{option}' is required."
+        },
+        "FormatOptionInvalid": {
+            "message": "The value passed for '{option}' is invalid: {reason}."
+        },
+        "FormatUnsuitable": {
+            "message": "Data can't be loaded from requested input format."
+        }
     }
 }

--- a/save_result.json
+++ b/save_result.json
@@ -46,6 +46,20 @@
             "type": "boolean"
         }
     },
+    "exceptions": {
+        "FormatUnsupported": {
+            "message": "Output format is not supported."
+        },
+        "FormatOptionRequired": {
+            "message": "Format option '{option}' is required."
+        },
+        "FormatOptionInvalid": {
+            "message": "The value passed for '{option}' is invalid: {reason}."
+        },
+        "FormatUnsuitable": {
+            "message": "Data can't be transformed into the requested output format."
+        }
+    },
     "links": [
         {
             "rel": "about",


### PR DESCRIPTION
see #177 

Based a bit on the original (removed) errors from openeo-api, including placeholders, I'm however not sure this is allowed as there seem to be no other exception messages with placeholders in openeo-processes