### PR TITLE
Remove `process_graph` example from arcosh (also see #151)

### DIFF
--- a/arcosh.json
+++ b/arcosh.json
@@ -32,26 +32,6 @@
                 "x": 1
             },
             "returns": 0
-        },
-        {
-            "process_graph": {
-                "cosh1": {
-                    "process_id": "cosh",
-                    "arguments": {
-                        "x": 0.5
-                    }
-                },
-                "arccosh1": {
-                    "process_id": "arcosh",
-                    "arguments": {
-                        "x": {
-                            "from_node": "cosh1"
-                        }
-                    },
-                    "result": true
-                }
-            },
-            "returns": 0.5
         }
     ],
     "links": [


### PR DESCRIPTION
The `process_graph` example, which is not valid anymore (Open-EO/openeo-api#285), broke (D28) validation of our backend because use the process specs directly through a git submodule