### PR TITLE
Make it easier to distinguish strings (paths/urls/code/...)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Moved the experimental processes `aggregate_spatial_binary`, `reduce_dimension_binary` and `run_udf_externally` to the proposals.
     - Moved the rarely used and implemented processes `cummax`, `cummin`, `cumproduct`, `cumsum`, `debug`, `filter_labels`, `load_result`, `load_uploaded_files`, `resample_cube_temporal` to the proposals.
 - Exception messages have been aligned always use ` instead of '. Tooling could render it with CommonMark.
+- `run_udf` and `run_udf_externally`: Specify specific (extensible) protocols for UDF URIs.
 
 ### Fixed
 - Clarify that the user workspace is server-side. [#225](https://github.com/Open-EO/openeo-processes/issues/225)
@@ -33,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed typos, grammar issues and other spelling-related issues in many of the processes.
 - Fixed the examples `array_contains_nodata` and `array_find_nodata`.
 - Fixed links to openEO glossary and added links to data cube introduction. [#216](https://github.com/Open-EO/openeo-processes/issues/216)
+- Clarified disallowed characters in subtype `file-path`.
+- Clarified that UDF source code must contain a newline/line-break (affects `run_udf`).
 
 ## 1.0.0 - 2020-07-31
 

--- a/meta/subtype-schemas.json
+++ b/meta/subtype-schemas.json
@@ -143,6 +143,7 @@
         "file-path": {
             "type": "string",
             "subtype": "file-path",
+            "pattern": "^[^\r\n\\:'\"]+$",
             "title": "Single File path",
             "description": "A relative path to a user-uploaded file. Folders can't be specified."
         },
@@ -381,7 +382,8 @@
             "type": "string",
             "subtype": "udf-code",
             "title": "UDF source code",
-            "description": "The (multi-line) source code of an user-defined function (UDF)."
+            "description": "The multi-line source code of a user-defined function (UDF), must contain a newline/line-break.",
+            "pattern": "(\r\n|\r|\n)"
         },
         "udf-runtime": {
             "type": "string",
@@ -400,7 +402,7 @@
             "subtype": "uri",
             "format": "uri",
             "title": "URI",
-            "description": "A valid URI according to [RFC3986](https://www.rfc-editor.org/rfc/rfc3986.html)."
+            "description": "A valid URI according to [RFC3986](https://www.rfc-editor.org/rfc/rfc3986.html). Can be restricted using a regex pattern."
         },
         "vector-cube": {
             "type": "object",

--- a/proposals/load_uploaded_files.json
+++ b/proposals/load_uploaded_files.json
@@ -16,7 +16,8 @@
                 "subtype": "file-paths",
                 "items": {
                     "type": "string",
-                    "subtype": "file-path"
+                    "subtype": "file-path",
+                    "pattern": "^[^\r\n\\:'\"]+$"
                 }
             }
         },

--- a/proposals/run_udf_externally.json
+++ b/proposals/run_udf_externally.json
@@ -34,11 +34,12 @@
         },
         {
             "name": "url",
-            "description": "URL to a remote UDF service.",
+            "description": "Absolute URL to a remote UDF service.",
             "schema": {
                 "type": "string",
                 "format": "uri",
-                "subtype": "uri"
+                "subtype": "uri",
+                "pattern": "^(http|https)://"
             }
         },
         {

--- a/run_udf.json
+++ b/run_udf.json
@@ -36,20 +36,23 @@
             "description": "Either source code, an absolute URL or a path to a UDF script.",
             "schema": [
                 {
-                    "description": "URI to a UDF",
+                    "description": "Absolute URL to a UDF",
                     "type": "string",
                     "format": "uri",
-                    "subtype": "uri"
+                    "subtype": "uri",
+                    "pattern": "^(http|https)://"
                 },
                 {
                     "description": "Path to a UDF uploaded to the server.",
                     "type": "string",
-                    "subtype": "file-path"
+                    "subtype": "file-path",
+                    "pattern": "^[^\r\n\\:'\"]+$"
                 },
                 {
-                    "description": "Source code as string",
+                    "description": "The multi-line source code of a UDF, must contain a newline/line-break.",
                     "type": "string",
-                    "subtype": "udf-code"
+                    "subtype": "udf-code",
+                    "pattern": "(\r\n|\r|\n)"
                 }
             ]
         },


### PR DESCRIPTION
Add regex patterns to subtypes to make them easier to distinguish if used for the same parameter (see run_udf).

* The file-path is aligned with the API, see https://github.com/Open-EO/openeo-api/pull/385
* The uri is now clearly an absolute URL in UDF processes (was already the case in run_udf) and we can enforce specific protocols in the schemas. Back-ends can extend that, e.g. by adding s3 or gcs.
* The udf-code is likely controversial, but I couldn't come up with good examples of a single line UDF and the subtype-schema already said it should be multi-line.

The idea came up when discussing #220.