### PR TITLE
Specify resampling method in sar backscatter processes to be bilinear

### DIFF
--- a/proposals/ard_normalized_radar_backscatter.json
+++ b/proposals/ard_normalized_radar_backscatter.json
@@ -1,7 +1,7 @@
 {
     "id": "ard_normalized_radar_backscatter",
     "summary": "CARD4L compliant SAR NRB generation",
-    "description": "Computes CARD4L compliant backscatter from SAR input. The radiometric correction coefficient is gamma0 (terrain), which is the ground area computed with terrain earth model in sensor line of sight.\n\nNote that backscatter computation may require instrument specific metadata that is tightly coupled to the original SAR products. As a result, this process may only work in combination with loading data from specific collections, not with general data cubes.",
+    "description": "Computes CARD4L compliant backscatter from SAR input. The radiometric correction coefficient is gamma0 (terrain), which is the ground area computed with terrain earth model in sensor line of sight.\n\nNote that backscatter computation may require instrument specific metadata that is tightly coupled to the original SAR products. As a result, this process may only work in combination with loading data from specific collections, not with general data cubes.\n\nThis process uses bilinear interpolation, both for resampling the DEM and the backscatter.",
     "categories": [
         "cubes",
         "sar",
@@ -82,6 +82,11 @@
             "rel": "about",
             "href": "https://bok.eo4geo.eu/PP2-2-4-3",
             "title": "Gamma nought (0) explained by EO4GEO body of knowledge."
+        },
+        {
+            "rel": "about",
+            "href": "https://doi.org/10.3390/data4030093",
+            "title": "Reasoning behind the choice of bilinear resampling"
         }
     ],
     "process_graph": {

--- a/proposals/sar_backscatter.json
+++ b/proposals/sar_backscatter.json
@@ -1,7 +1,7 @@
 {
     "id": "sar_backscatter",
     "summary": "Computes backscatter from SAR input",
-    "description": "Computes backscatter from SAR input.\n\nNote that backscatter computation may require instrument specific metadata that is tightly coupled to the original SAR products. As a result, this process may only work in combination with loading data from specific collections, not with general data cubes.",
+    "description": "Computes backscatter from SAR input.\n\nNote that backscatter computation may require instrument specific metadata that is tightly coupled to the original SAR products. As a result, this process may only work in combination with loading data from specific collections, not with general data cubes.\n\nThis process uses bilinear interpolation, both for resampling the DEM and the backscatter.",
     "categories": [
         "cubes",
         "sar"
@@ -126,6 +126,11 @@
             "rel": "about",
             "href": "https://www.geo.uzh.ch/microsite/rsl-documents/research/publications/peer-reviewed-articles/201108-TGRS-Small-tcGamma-3809999360/201108-TGRS-Small-tcGamma.pdf",
             "title": "Flattening Gamma: Radiometric Terrain Correction for SAR Imagery"
+        },
+        {
+            "rel": "about",
+            "href": "https://doi.org/10.3390/data4030093",
+            "title": "Reasoning behind the choice of bilinear resampling"
         }
     ]
 }


### PR DESCRIPTION
Specify that the resampling method in SAR backscatter processes is required to be bilinear, see #249 for details.