### PR TITLE
Clarified use of geometries in aggregate_spatial processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed links to openEO glossary and added links to data cube introduction. [#216](https://github.com/Open-EO/openeo-processes/issues/216)
 - Clarified disallowed characters in subtype `file-path`.
 - Clarified that UDF source code must contain a newline/line-break (affects `run_udf`).
+- `aggregate_spatial`, `aggregate_spatial_binary`: Clarified that Multi* geometries are a single entity in computations. GeometryCollections are considered being multiple entities. [#252](https://github.com/Open-EO/openeo-processes/issues/252)
 
 ## 1.0.0 - 2020-07-31
 

--- a/aggregate_spatial.json
+++ b/aggregate_spatial.json
@@ -1,7 +1,7 @@
 {
     "id": "aggregate_spatial",
     "summary": "Zonal statistics for geometries",
-    "description": "Aggregates statistics for one or more geometries (e.g. zonal statistics for polygons) over the spatial dimensions. This process passes a list of values to the reducer. In contrast, ``aggregate_spatial_binary()`` passes two values, which may be better suited especially for UDFs in case the number of values gets too large to be processed at once.\n\n- For **polygons**, the process considers all pixels for which the point at the pixel center intersects with the corresponding polygon (as defined in the Simple Features standard by the OGC).\n- For **points**, the process considers the closest pixel center.\n- For **lines** (line strings), the process considers all the pixels whose centers are closest to at least one point on the line.\n\nThus, pixels may be part of multiple geometries and be part of multiple aggregations.\n\nThe data cube must have been reduced to only contain two spatial dimensions and a third dimension the values are aggregated for, for example the temporal dimension to get a time series. Otherwise, this process fails with the `TooManyDimensions` exception.\n\nThe number of total and valid pixels is returned together with the calculated values.",
+    "description": "Aggregates statistics for one or more geometries (e.g. zonal statistics for polygons) over the spatial dimensions. This process passes a list of values to the reducer. In contrast, ``aggregate_spatial_binary()`` passes two values, which may be better suited especially for UDFs in case the number of values gets too large to be processed at once.\n\nThe data cube must have been reduced to only contain two spatial dimensions and a third dimension the values are aggregated for, for example the temporal dimension to get a time series. Otherwise, this process fails with the `TooManyDimensions` exception.\n\nThe number of total and valid pixels is returned together with the calculated values.",
     "categories": [
         "cubes",
         "aggregate & resample"
@@ -17,7 +17,7 @@
         },
         {
             "name": "geometries",
-            "description": "Geometries as GeoJSON on which the aggregation will be based.",
+            "description": "Geometries as GeoJSON on which the aggregation will be based. One value will be computed per GeoJSON geometry, which means that, for example, a single value will be computed for a `MultiPolgon`, but two values will be computed for a `FeatureCollection` or `GeometryCollection` containing two polygons.\n\n- For **polygons**, the process considers all pixels for which the point at the pixel center intersects with the corresponding polygon (as defined in the Simple Features standard by the OGC).\n- For **points**, the process considers the closest pixel center.\n- For **lines** (line strings), the process considers all the pixels whose centers are closest to at least one point on the line.\n\nThus, pixels may be part of multiple geometries and be part of multiple aggregations.",
             "schema": {
                 "type": "object",
                 "subtype": "geojson"

--- a/proposals/aggregate_spatial_binary.json
+++ b/proposals/aggregate_spatial_binary.json
@@ -1,7 +1,7 @@
 {
     "id": "aggregate_spatial_binary",
     "summary": "Zonal statistics for geometries by binary aggregation",
-    "description": "Aggregates statistics for one or more geometries (e.g. zonal statistics for polygons) over the spatial dimensions. This process consecutively passes a pair of values to the reducer. This may be better suited especially for UDFs in case the number of values gets too large to be processed at once. In contrast, ``aggregate_spatial()`` passes a list of values.\n\n- For **polygons**, the process considers all pixels for which the point at the pixel center intersects with the corresponding polygon (as defined in the Simple Features standard by the OGC).\n- For **points**, the process considers the closest pixel center.\n- For **lines** (line strings), the process considers all the pixels whose centers are closest to at least one point on the line.\n\nThe data cube must have been reduced to only contain two raster dimensions and a third dimension the values are aggregated for, for example the temporal dimension to get a time series. Otherwise, this process fails with the `TooManyDimensions` exception.\n\nThe number of total and valid pixels is returned together with the calculated values.",
+    "description": "Aggregates statistics for one or more geometries (e.g. zonal statistics for polygons) over the spatial dimensions. This process consecutively passes a pair of values to the reducer. This may be better suited especially for UDFs in case the number of values gets too large to be processed at once. In contrast, ``aggregate_spatial()`` passes a list of values.\n\nThe data cube must have been reduced to only contain two raster dimensions and a third dimension the values are aggregated for, for example the temporal dimension to get a time series. Otherwise, this process fails with the `TooManyDimensions` exception.\n\nThe number of total and valid pixels is returned together with the calculated values.",
     "categories": [
         "cubes",
         "aggregate & resample"
@@ -18,7 +18,7 @@
         },
         {
             "name": "geometries",
-            "description": "Geometries as GeoJSON on which the aggregation will be based.",
+            "description": "Geometries as GeoJSON on which the aggregation will be based. One value will be computed per GeoJSON geometry, which means that, for example, a single value will be computed for a `MultiPolgon`, but two values will be computed for a `FeatureCollection` or `GeometryCollection` containing two polygons.\n\n- For **polygons**, the process considers all pixels for which the point at the pixel center intersects with the corresponding polygon (as defined in the Simple Features standard by the OGC).\n- For **points**, the process considers the closest pixel center.\n- For **lines** (line strings), the process considers all the pixels whose centers are closest to at least one point on the line.\n\nThus, pixels may be part of multiple geometries and be part of multiple aggregations.",
             "schema": {
                 "type": "object",
                 "subtype": "geojson"


### PR DESCRIPTION
Improvements for aggregate_spatial processes, see #252:

- Clarified: One value will be computed per GeoJSON geometry, which means that, for example, a single value will be computed for a `MultiPolgon`, but two values will be computed for a `FeatureCollection` or `GeometryCollection` containing two polygons.
- Moved the details about geometries from the process description to the description of the parameter `geometries` to have related descriptions in a single place.

This behavior of MultiPolygons / Polygons is aligned with the VITO implementation AFAIK. Not sure about GeometryCollections.