### PR TITLE
aggregate_temporal(_period): handling of empty intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `aggregate_spatial`: Clarified that the values have no predefined order and reducers such as `first` and `last` return unpredictable results. [#260](https://github.com/Open-EO/openeo-processes/issues/260)
 - `load_collection`, parameter `spatial_extent`: Clarified that all pixels that are inside the bounding box of the given polygons but do not intersect with any polygon have to be set to no-data (`null`). [#256](https://github.com/Open-EO/openeo-processes/issues/256)
 - `load_collection`: Clarified that the parameters are recommended to be used in favor of `filter_*` processes.
+- `aggregate_temporal` and `aggregate_temporal_period`: Clarified that reducers are also executed for intervals/periods with no data. [#263](https://github.com/Open-EO/openeo-processes/issues/263)
 
 ## 1.0.0 - 2020-07-31
 

--- a/aggregate_temporal.json
+++ b/aggregate_temporal.json
@@ -87,14 +87,14 @@
         },
         {
             "name": "reducer",
-            "description": "A reducer to be applied on all values along the specified dimension. A reducer is a single process such as ``mean()`` or a set of processes, which computes a single value for a list of values, see the category 'reducer' for such processes.",
+            "description": "A reducer to be applied for the values contained in each interval. A reducer is a single process such as ``mean()`` or a set of processes, which computes a single value for a list of values, see the category 'reducer' for such processes. Intervals may not contain any values, which for most reducers leads to no-data (`null`) values by default.",
             "schema": {
                 "type": "object",
                 "subtype": "process-graph",
                 "parameters": [
                     {
                         "name": "data",
-                        "description": "A labeled array with elements of any type.",
+                        "description": "A labeled array with elements of any type. If there's no data for the interval, the array is empty.",
                         "schema": {
                             "type": "array",
                             "subtype": "labeled-array",

--- a/aggregate_temporal_period.json
+++ b/aggregate_temporal_period.json
@@ -37,14 +37,14 @@
         },
         {
             "name": "reducer",
-            "description": "A reducer to be applied on all values along the specified dimension. A reducer is a single process such as ``mean()`` or a set of processes, which computes a single value for a list of values, see the category 'reducer' for such processes.",
+            "description": "A reducer to be applied for the values contained in each period. A reducer is a single process such as ``mean()`` or a set of processes, which computes a single value for a list of values, see the category 'reducer' for such processes. Periods may not contain any values, which for most reducers leads to no-data (`null`) values by default.",
             "schema": {
                 "type": "object",
                 "subtype": "process-graph",
                 "parameters": [
                     {
                         "name": "data",
-                        "description": "A labeled array with elements of any type.",
+                        "description": "A labeled array with elements of any type. If there's no data for the period, the array is empty.",
                         "schema": {
                             "type": "array",
                             "subtype": "labeled-array",


### PR DESCRIPTION
Fixes #263 

Could potentially be part of 1.1.0.