### PR TITLE
Add array_create_labels process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `array_append`
     - `array_concat`
     - `array_create`
+    - `array_create_labels`
     - `array_find_label`
     - `array_interpolate_linear` [#173](https://github.com/Open-EO/openeo-processes/issues/173)
     - `array_modify`

--- a/proposals/array_create_labels.json
+++ b/proposals/array_create_labels.json
@@ -1,0 +1,46 @@
+{
+    "id": "array_create_labels",
+    "summary": "Create a labeled array",
+    "description": "Creates a new labeled array by using the values from the `labels` array as labels and the values from the `data` array as the corresponding values.\n\nThe exception `ArrayLengthMismatch` is thrown, if the number of the values in the given arrays don't match exactly.\n\nThe primary use case here is to be able to transmit labeled arrays from the client to the server as JSON doesn't support this data type.",
+    "categories": [
+        "arrays"
+    ],
+    "experimental": true,
+    "parameters": [
+        {
+            "name": "data",
+            "description": "An array of values to be used.",
+            "schema": {
+                "description": "Any data type is allowed."
+            }
+        },
+        {
+            "name": "labels",
+            "description": "An array of labels to be used.",
+            "schema": {
+                "type": "array",
+                "items": {
+                    "type": [
+                        "number",
+                        "string"
+                    ]
+                }
+            }
+        }
+    ],
+    "returns": {
+        "description": "The newly created labeled array.",
+        "schema": {
+            "type": "array",
+            "subtype": "labeled-array",
+            "items": {
+                "description": "Any data type is allowed."
+            }
+        }
+    },
+    "exceptions": {
+        "ArrayLengthMismatch": {
+            "message": "The number of values in the parameters `data` and `labels` don't match."
+        }
+    }
+}


### PR DESCRIPTION
This fills a gap in the processes as we can't transmit labeled arrays easily via JSON. So this makes it possible for users to actually construct those and make use of processes that require labeled arrays to be passed.

The idea came up when writing up the `fit_curve` process in PR #240.