### PR TITLE
Improve quantiles #278, add statistics category #277

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `fit_curve`
     - `predict_curve`
 - `run_udf`: Exception `InvalidRuntime` added
+- A new category "math > statistics" has been added [#277](https://github.com/Open-EO/openeo-processes/issues/277)
 
 ### Changed
 
@@ -25,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `aggregate_temporal_period`: Clarified which dimension labels are present in the returned data cube. [#274](https://github.com/Open-EO/openeo-processes/issues/274)
 - `ard_surface_reflectance`: has been categorized as "optical" instead of "sar".
+- `quantiles`: Clarified behavior. [#278](https://github.com/Open-EO/openeo-processes/issues/278)
 
 ## [1.1.0] - 2021-06-29
 

--- a/count.json
+++ b/count.json
@@ -4,6 +4,7 @@
     "description": "Gives the number of elements in an array that matches the specified condition.\n\n**Remarks:**\n\n* Counts the number of valid elements by default (`condition` is set to `null`). A valid element is every element for which ``is_valid()`` returns `true`.\n* To count all elements in a list set the `condition` parameter to boolean `true`.",
     "categories": [
         "arrays",
+        "math > statistics",
         "reducer"
     ],
     "parameters": [

--- a/extrema.json
+++ b/extrema.json
@@ -3,7 +3,7 @@
     "summary": "Minimum and maximum values",
     "description": "Two element array containing the minimum and the maximum values of `data`.\n\nThis process is basically an alias for calling both ``min()`` and ``max()``, but may be implemented more performant by back-ends as it only needs to iterate over the data once instead of twice.",
     "categories": [
-        "math"
+        "math > statistics"
     ],
     "parameters": [
         {

--- a/max.json
+++ b/max.json
@@ -4,6 +4,7 @@
     "description": "Computes the largest value of an array of numbers, which is equal to the first element of a sorted (i.e., ordered) version of the array.\n\nAn array without non-`null` elements resolves always with `null`.",
     "categories": [
         "math",
+        "math > statistics",
         "reducer"
     ],
     "parameters": [

--- a/mean.json
+++ b/mean.json
@@ -3,7 +3,7 @@
     "summary": "Arithmetic mean (average)",
     "description": "The arithmetic mean of an array of numbers is the quantity commonly called the average. It is defined as the sum of all elements divided by the number of elements.\n\nAn array without non-`null` elements resolves always with `null`.",
     "categories": [
-        "math",
+        "math > statistics",
         "reducer"
     ],
     "parameters": [

--- a/median.json
+++ b/median.json
@@ -3,7 +3,7 @@
     "summary": "Statistical median",
     "description": "The statistical median of an array of numbers is the value separating the higher half from the lower half of the data.\n\nAn array without non-`null` elements resolves always with `null`.\n\n**Remarks:**\n\n* For symmetric arrays, the result is equal to the ``mean()``.\n* The median can also be calculated by computing the ``quantiles()`` with a probability of *0.5*.",
     "categories": [
-        "math",
+        "math > statistics",
         "reducer"
     ],
     "parameters": [

--- a/min.json
+++ b/min.json
@@ -4,6 +4,7 @@
     "description": "Computes the smallest value of an array of numbers, which is equal to the last element of a sorted (i.e., ordered) version of the array.\n\nAn array without non-`null` elements resolves always with `null`.",
     "categories": [
         "math",
+        "math > statistics",
         "reducer"
     ],
     "parameters": [

--- a/quantiles.json
+++ b/quantiles.json
@@ -1,9 +1,9 @@
 {
     "id": "quantiles",
     "summary": "Quantiles",
-    "description": "Calculates quantiles, which are cut points dividing the range of a probability distribution into either\n\n* intervals corresponding to the given `probabilities` or\n* (nearly) equal-sized intervals (q-quantiles based on the parameter `q`).\n\nEither the parameter `probabilities` or `q` must be specified, otherwise the `QuantilesParameterMissing` exception is thrown. If both parameters are set the `QuantilesParameterConflict` exception is thrown.",
+    "description": "Calculates quantiles, which are cut points dividing the range of a sample distribution into either\n\n* intervals corresponding to the given `probabilities` or\n* equal-sized intervals (q-quantiles based on the parameter `q`).\n\nEither the parameter `probabilities` or `q` must be specified, otherwise the `QuantilesParameterMissing` exception is thrown. If both parameters are set the `QuantilesParameterConflict` exception is thrown.",
     "categories": [
-        "math"
+        "math > statistics"
     ],
     "parameters": [
         {
@@ -21,7 +21,7 @@
         },
         {
             "name": "probabilities",
-            "description": "A list of probabilities to calculate quantiles for. The probabilities must be between 0 and 1.",
+            "description": "A list of probabilities to calculate quantiles for. The probabilities must be between 0 and 1 (inclusive).",
             "schema": {
                 "type": "array",
                 "items": {
@@ -34,7 +34,7 @@
         },
         {
             "name": "q",
-            "description": "Intervals to calculate quantiles for. Calculates q-quantiles with (nearly) equal-sized intervals.",
+            "description": "Number of intervals to calculate quantiles for. Calculates q-quantiles with equal-sized intervals.",
             "schema": {
                 "type": "integer",
                 "minimum": 2

--- a/sd.json
+++ b/sd.json
@@ -3,7 +3,7 @@
     "summary": "Standard deviation",
     "description": "Computes the sample standard deviation, which quantifies the amount of variation of an array of numbers. It is defined to be the square root of the corresponding variance (see ``variance()``).\n\nA low standard deviation indicates that the values tend to be close to the expected value, while a high standard deviation indicates that the values are spread out over a wider range.\n\nAn array without non-`null` elements resolves always with `null`.",
     "categories": [
-        "math",
+        "math > statistics",
         "reducer"
     ],
     "parameters": [

--- a/variance.json
+++ b/variance.json
@@ -3,7 +3,7 @@
     "summary": "Variance",
     "description": "Computes the sample variance of an array of numbers by calculating the square of the standard deviation (see ``sd()``). It is defined to be the expectation of the squared deviation of a random variable from its expected value. Basically, it measures how far the numbers in the array are spread out from their average value.\n\nAn array without non-`null` elements resolves always with `null`.",
     "categories": [
-        "math",
+        "math > statistics",
         "reducer"
     ],
     "parameters": [


### PR DESCRIPTION
First draft for #277 and #278.

- [x] Added "math > statistics" category to processes for a more fine-grained categorization #277
- [x] Remove "nearly" from quantiles process #278
- [x] Make clear that the probabilities array is inclusive
- [x] Clarify "intervals to calculate" => "the number of intervals to calculate"

Still to do (open for suggestions):
- [x] Wording around probabilities. This is general statistical language and is potentially useful to define, but @soxofann raises that this is not really fitting here.
- Check whether we also want to implement #293 (deprecate parameter probabilities, unify to parameter q) -> separate PR