### PR TITLE
Improve support for labeled arrays in experimental array processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased / Draft
 
+### Changed
+
+- Added better support for labeled arrays. Labels are not discarded in all cases anymore. Affected processes:
+    - `array_append`
+    - `array_concat`
+    - `array_modify`
+
 ## [1.2.0] - 2021-12-13
 
 ### Added

--- a/proposals/array_append.json
+++ b/proposals/array_append.json
@@ -1,7 +1,7 @@
 {
     "id": "array_append",
     "summary": "Append a value to an array",
-    "description": "Appends a value to the end of the array. Array labels get discarded from the array.",
+    "description": "Appends a new value to the end of the array, which may also include a new label for labeled arrays.",
     "categories": [
         "arrays"
     ],
@@ -23,6 +23,18 @@
             "schema": {
                 "description": "Any data type is allowed."
             }
+        },
+        {
+            "name": "label",
+            "description": "If the given array is a labeled array, a new label for the new value should be given. If not given or `null`, the array index as string is used as the label. If in any case the label exists, a `LabelExists` exception is thrown.",
+            "optional": true,
+            "default": null,
+            "schema": {
+                "type": [
+                    "string",
+                    "null"
+                ]
+            }
         }
     ],
     "returns": {
@@ -32,6 +44,11 @@
             "items": {
                 "description": "Any data type is allowed."
             }
+        }
+    },
+    "exceptions": {
+        "LabelExists": {
+            "message": "A label with the specified name exists."
         }
     },
     "examples": [
@@ -49,21 +66,5 @@
                 3
             ]
         }
-    ],
-    "process_graph": {
-        "append": {
-            "process_id": "array_concat",
-            "arguments": {
-                "array1": {
-                    "from_parameter": "data"
-                },
-                "array2": [
-                    {
-                        "from_parameter": "value"
-                    }
-                ]
-            },
-            "result": true
-        }
-    }
+    ]
 }

--- a/proposals/array_append.json
+++ b/proposals/array_append.json
@@ -48,7 +48,7 @@
     },
     "exceptions": {
         "LabelExists": {
-            "message": "A label with the specified name exists."
+            "message": "An array element with the specified label already exists."
         }
     },
     "examples": [

--- a/proposals/array_concat.json
+++ b/proposals/array_concat.json
@@ -1,7 +1,7 @@
 {
     "id": "array_concat",
     "summary": "Merge two arrays",
-    "description": "Concatenates two arrays into a single array by appending the second array to the first array. Array labels get discarded from both arrays before merging.",
+    "description": "Concatenates two arrays into a single array by appending the second array to the first array. Array labels are kept only if both given arrays are labeled. Otherwise, the labels get discarded from both arrays.",
     "categories": [
         "arrays"
     ],

--- a/proposals/array_concat.json
+++ b/proposals/array_concat.json
@@ -1,7 +1,7 @@
 {
     "id": "array_concat",
     "summary": "Merge two arrays",
-    "description": "Concatenates two arrays into a single array by appending the second array to the first array. Array labels are kept only if both given arrays are labeled. Otherwise, the labels get discarded from both arrays.",
+    "description": "Concatenates two arrays into a single array by appending the second array to the first array.\n\nArray labels are kept only if both given arrays are labeled. Otherwise, the labels get discarded from both arrays. The process fails with an `ArrayLabelConflict` exception if a label is present in both arrays. Conflicts must be resolved beforehand.",
     "categories": [
         "arrays"
     ],
@@ -35,6 +35,11 @@
             "items": {
                 "description": "Any data type is allowed."
             }
+        }
+    },
+    "exceptions": {
+        "ArrayLabelConflict": {
+            "message": "At least one label exists in both arrays and the conflict must be resolved before."
         }
     },
     "examples": [

--- a/proposals/array_modify.json
+++ b/proposals/array_modify.json
@@ -1,7 +1,7 @@
 {
     "id": "array_modify",
     "summary": "Change the content of an array (remove, insert, update)",
-    "description": "Modify an array by removing, inserting or updating elements. Updating can be seen as removing elements followed by inserting new elements (not necessarily the same number).\n\nAll labels get discarded and the array indices are always a sequence of numbers with the step size of 1 and starting at 0.",
+    "description": "Modify an array by removing, inserting or updating elements. Updating can be seen as removing elements followed by inserting new elements (not necessarily the same number).\n\nArray labels are kept only if both arrays given in `data` and `values` are labeled (or empty). Otherwise, all labels get discarded and the array indices are a sequence of numbers with the step size of 1 and starting at 0.",
     "categories": [
         "arrays"
     ],

--- a/proposals/array_modify.json
+++ b/proposals/array_modify.json
@@ -1,7 +1,7 @@
 {
     "id": "array_modify",
     "summary": "Change the content of an array (remove, insert, update)",
-    "description": "Modify an array by removing, inserting or updating elements. Updating can be seen as removing elements followed by inserting new elements (not necessarily the same number).\n\nArray labels are kept only if both arrays given in `data` and `values` are labeled (or empty). Otherwise, all labels get discarded and the array indices are a sequence of numbers with the step size of 1 and starting at 0.",
+    "description": "Modify an array by removing, inserting or updating elements. Updating can be seen as removing elements followed by inserting new elements (not necessarily the same number).\n\nArray labels are kept only if both arrays given in `data` and `values` are labeled or one of them is empty. Otherwise, all labels get discarded and the array indices are a sequence of numbers with the step size of 1 and starting at 0. The process fails with an `ArrayLabelConflict` exception if a label is present in both arrays.",
     "categories": [
         "arrays"
     ],
@@ -58,6 +58,9 @@
     "exceptions": {
         "ArrayElementNotAvailable": {
             "message": "The array can't be modified as the given index is larger than the number of elements in the array."
+        },
+        "ArrayLabelConflict": {
+            "message": "At least one label exists in both arrays and the conflict must be resolved before."
         }
     },
     "examples": [


### PR DESCRIPTION
Added better support for labeled arrays in experimental array processes that previously simply discarded the labels. Affected processes:
- `array_append`
- `array_concat`
- `array_modify`

The idea is that this will help overall to improve support for labeled arrays and get a better solution for #233, e.g. through a modified version of `apply_dimension` (as discussed with @clausmichele).