### PR TITLE
Allow loading vector cubes in load_... processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `array_modify`
 - Moved the `text_` processes to proposals as they are lacking implementations.
 - Renamed `text_merge` to `text_concat` for better alignment with `array_concat`.
+- Allow loading vector data cubes with:
+    - `load_collection`
+    - `load_result`
+    - `load_uploaded_files`
 
 ### Fixed
 

--- a/load_collection.json
+++ b/load_collection.json
@@ -216,10 +216,16 @@
     ],
     "returns": {
         "description": "A data cube for further processing. The dimensions and dimension properties (name, type, labels, reference system and resolution) correspond to the collection's metadata, but the dimension labels are restricted as specified in the parameters.",
-        "schema": {
-            "type": "object",
-            "subtype": "raster-cube"
-        }
+        "schema": [
+            {
+                "type": "object",
+                "subtype": "raster-cube"
+            },
+            {
+                "type": "object",
+                "subtype": "vector-cube"
+            }
+        ]
     },
     "examples": [
         {

--- a/proposals/load_result.json
+++ b/proposals/load_result.json
@@ -193,9 +193,15 @@
     ],
     "returns": {
         "description": "A data cube for further processing.",
-        "schema": {
-            "type": "object",
-            "subtype": "raster-cube"
-        }
+        "schema": [
+            {
+                "type": "object",
+                "subtype": "raster-cube"
+            },
+            {
+                "type": "object",
+                "subtype": "vector-cube"
+            }
+        ]
     }
 }

--- a/proposals/load_uploaded_files.json
+++ b/proposals/load_uploaded_files.json
@@ -42,10 +42,16 @@
     ],
     "returns": {
         "description": "A data cube for further processing.",
-        "schema": {
-            "type": "object",
-            "subtype": "raster-cube"
-        }
+        "schema": [
+            {
+                "type": "object",
+                "subtype": "raster-cube"
+            },
+            {
+                "type": "object",
+                "subtype": "vector-cube"
+            }
+        ]
     },
     "exceptions": {
         "FormatUnsuitable": {


### PR DESCRIPTION
Allow loading vector data cubes via load_collection, load_result and load_uploaded_files as discussed in the dev telco @jdries .
Currently, only adds the schema. May need some additional descriptive text or so, thus still in draft.

Open question: Bands are pretty much raster-based. We need to check what makes sense there.