### PR TITLE
`round`: Clarify that the rounding for ties applies not only for integers. #326

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `aggregate_spatial`: Clarified that vector properties are preserved for vector data cubes and all GeoJSON Features. [#270](https://github.com/Open-EO/openeo-processes/issues/270)
 - `apply_neighborhood`: Parameter `overlap` was optional but had no default value and no schena for the default value defined.
 - `rename_labels`: Clarified that the `LabelsNotEnumerated` exception is thrown if `source` is empty instead of if `target` is empty. [#321](https://github.com/Open-EO/openeo-processes/issues/321)
+- `round`: Clarify that the rounding for ties applies not only for integers. [#326](https://github.com/Open-EO/openeo-processes/issues/326)
 
 ## [1.2.0] - 2021-12-13
 

--- a/round.json
+++ b/round.json
@@ -1,7 +1,7 @@
 {
     "id": "round",
     "summary": "Round to a specified precision",
-    "description": "Rounds a real number `x` to specified precision `p`.\n\nIf the fractional part of `x` is halfway between two integers, one of which is even and the other odd, then the even number is returned.\nThis behavior follows [IEEE Standard 754](https://ieeexplore.ieee.org/document/8766229). This kind of rounding is also called \"round to nearest (even)\" or \"banker's rounding\". It minimizes rounding errors that result from consistently rounding a midpoint value in a single direction.\n\nThe no-data value `null` is passed through and therefore gets propagated.",
+    "description": "Rounds a real number `x` to specified precision `p`.\n\nIf the reamining part of `x` that is relevant for rounding under consideration of `p` is halfway between two numbers, one of which is even and the other odd, then the even number gets rounded to.\nThis behavior follows [IEEE Standard 754](https://ieeexplore.ieee.org/document/8766229) and is often called \"round to nearest (even)\" or \"banker's rounding\". It minimizes rounding errors that result from consistently rounding a midpoint value in a single direction.\n\nThe no-data value `null` is passed through and therefore gets propagated.",
     "categories": [
         "math > rounding"
     ],
@@ -67,6 +67,20 @@
                 "x": -3.5
             },
             "returns": -4
+        },
+        {
+            "arguments": {
+                "x": 0.25,
+                "p": 1
+            },
+            "returns": 0.2
+        },
+        {
+            "arguments": {
+                "x": 0.35,
+                "p": 1
+            },
+            "returns": 0.4
         },
         {
             "arguments": {

--- a/round.json
+++ b/round.json
@@ -1,7 +1,7 @@
 {
     "id": "round",
     "summary": "Round to a specified precision",
-    "description": "Rounds a real number `x` to specified precision `p`.\n\nIf the reamining part of `x` that is relevant for rounding under consideration of `p` is halfway between two numbers, one of which is even and the other odd, then the even number gets rounded to.\nThis behavior follows [IEEE Standard 754](https://ieeexplore.ieee.org/document/8766229) and is often called \"round to nearest (even)\" or \"banker's rounding\". It minimizes rounding errors that result from consistently rounding a midpoint value in a single direction.\n\nThe no-data value `null` is passed through and therefore gets propagated.",
+    "description": "Rounds a real number `x` to specified precision `p`.\n\nIf `x` is halfway between closest numbers of precision `p`, it is rounded to the closest even number of precision `p`.\nThis behavior follows [IEEE Standard 754](https://ieeexplore.ieee.org/document/8766229) and is often called \"round to nearest (even)\" or \"banker's rounding\". It minimizes rounding errors that result from consistently rounding a midpoint value in a single direction.\n\nThe no-data value `null` is passed through and therefore gets propagated.",
     "categories": [
         "math > rounding"
     ],


### PR DESCRIPTION
Tries to fix #326. I found it relatively hard to describe the behavior in "simple" English, it may need further fine-tuning. Thoughts?