### PR TITLE
`apply_neighborhood`: Allow `null` as default value for units.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `array_modify`
 - Moved the `text_` processes to proposals as they are lacking implementations.
 - Renamed `text_merge` to `text_concat` for better alignment with `array_concat`.
+- `apply_neighborhood`: Allow `null` as default value for units.
 
 ### Fixed
 

--- a/apply_neighborhood.json
+++ b/apply_neighborhood.json
@@ -85,11 +85,21 @@
                             ]
                         },
                         "unit": {
-                            "type": "string",
-                            "description": "The unit the values are given in, either in meters (`m`) or pixels (`px`). If no unit is given, uses the unit specified for the dimension or otherwise the default unit of the reference system.",
-                            "enum": [
-                                "px",
-                                "m"
+                            "description": "The unit the values are given in, either in meters (`m`) or pixels (`px`). If no unit or `null` is given, uses the unit specified for the dimension or otherwise the default unit of the reference system.",
+                            "default": null,
+                            "anyOf": [
+                                {
+                                    "title": "Default unit",
+                                    "type": "null"
+                                },
+                                {
+                                    "title": "Specific unit",
+                                    "type": "string",
+                                    "enum": [
+                                        "px",
+                                        "m"
+                                    ]
+                                }
                             ]
                         }
                     }
@@ -141,11 +151,21 @@
                                 ]
                             },
                             "unit": {
-                                "type": "string",
-                                "description": "The unit the values are given in, either in meters (`m`) or pixels (`px`). If no unit is given, uses the unit specified for the dimension or otherwise the default unit of the reference system.",
-                                "enum": [
-                                    "px",
-                                    "m"
+                                "description": "The unit the values are given in, either in meters (`m`) or pixels (`px`). If no unit or `null` is given, uses the unit specified for the dimension or otherwise the default unit of the reference system.",
+                                "default": null,
+                                "anyOf": [
+                                    {
+                                        "title": "Default unit",
+                                        "type": "null"
+                                    },
+                                    {
+                                        "title": "Specific unit",
+                                        "type": "string",
+                                        "enum": [
+                                            "px",
+                                            "m"
+                                        ]
+                                    }
                                 ]
                             }
                         }


### PR DESCRIPTION
We had a weird and uncommon behavior in apply_neighborhood, where you actually had to remove a parameter/property (instead of setting it to null or having null as the default value) to specify a specific behavior for the units. This PR is fixing this in a backward-compatible way by allowing null and setting the default value to null.