### PR TITLE
is_nodata: Clarify NaN #361

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `apply_neighborhood`: Parameter `overlap` was optional but had no default value and no schena for the default value defined.
 - `array_contains` and `array_find`: Clarify that giving `null` as `value` always returns `false` or `null` respectively, also fixed the incorrect examples. [#348](https://github.com/Open-EO/openeo-processes/issues/348)
 - `array_interpolate_linear`: Return value was incorrectly specified as `number` or `null`. It must return an array instead. [#333](https://github.com/Open-EO/openeo-processes/issues/333)
+- `is_nodata`: Clarified that `NaN` can be considered as no-data value is explicitly specified. [#361](https://github.com/Open-EO/openeo-processes/issues/361)
 - `rename_labels`: Clarified that the `LabelsNotEnumerated` exception is thrown if `source` is empty instead of if `target` is empty. [#321](https://github.com/Open-EO/openeo-processes/issues/321)
 - `round`: Clarify that the rounding for ties applies not only for integers. [#326](https://github.com/Open-EO/openeo-processes/issues/326)
 

--- a/is_nodata.json
+++ b/is_nodata.json
@@ -1,7 +1,7 @@
 {
     "id": "is_nodata",
     "summary": "Value is a no-data value",
-    "description": "Checks whether the specified data is missing data, i.e. equals to `null` or any of the no-data values specified in the metadata. The special numerical value `NaN` (not a number) as defined by the [IEEE Standard 754](https://ieeexplore.ieee.org/document/4610935) is not considered no-data and must return `false`.",
+    "description": "Checks whether the specified data is missing data, i.e. equals to `null` or any of the no-data values specified in the metadata.\n\nThe special numerical value `NaN` (not a number) as defined by the [IEEE Standard 754](https://ieeexplore.ieee.org/document/4610935) is only considered as no-data value if specified as no-data value in the metdata.",
     "categories": [
         "comparison"
     ],


### PR DESCRIPTION
`is_nodata`: Clarified that `NaN` can be considered as no-data value is explicitly specified. 

Fixes #361