### PR TITLE
Generalize predict processes for ML models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `fit_regr_random_forest`
     - `flatten_dimensions`
     - `load_ml_model`
-    - `predict_random_forest`
+    - `predict_ml_model`
+    - `predict_ml_model_probabilities`
     - `save_ml_model`
     - `unflatten_dimension`
     - `vector_buffer`

--- a/proposals/load_ml_model.json
+++ b/proposals/load_ml_model.json
@@ -36,7 +36,7 @@
         }
     ],
     "returns": {
-        "description": "A machine learning model to be used with machine learning processes such as ``predict_random_forest()``.",
+        "description": "A machine learning model to be used with machine learning processes such as ``predict_ml_model()`` or ``predict_ml_model_probabilities()``.",
         "schema": {
             "type": "object",
             "subtype": "ml-model"

--- a/proposals/predict_curve.json
+++ b/proposals/predict_curve.json
@@ -1,6 +1,6 @@
 {
     "id": "predict_curve",
-    "summary": "Predict values",
+    "summary": "Predict values using a model function",
     "description": "Predict values using a model function and pre-computed parameters. The process is primarily intended to compute values for new labels, but it can also fill gaps where existing labels contain no-data (`null`) values.",
     "categories": [
         "cubes",

--- a/proposals/predict_ml_model.json
+++ b/proposals/predict_ml_model.json
@@ -1,0 +1,42 @@
+{
+    "id": "predict_ml_model",
+    "summary": "Predict values values using a ML model",
+    "description": "Applies a machine learning model to an array and predicts a value/class for it.",
+    "categories": [
+        "machine learning",
+        "reducer"
+    ],
+    "experimental": true,
+    "parameters": [
+        {
+            "name": "data",
+            "description": "An array of numbers.",
+            "schema": {
+                "type": "array",
+                "items": {
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                }
+            }
+        },
+        {
+            "name": "model",
+            "description": "A ML model that can be trained with one of the ML processes such as ``fit_class_random_forest()``.",
+            "schema": {
+                "type": "object",
+                "subtype": "ml-model"
+            }
+        }
+    ],
+    "returns": {
+        "description": "The predicted value. Returns `null` if any of the given values in the array is a no-data value.",
+        "schema": {
+            "type": [
+                "number",
+                "null"
+            ]
+        }
+    }
+}

--- a/proposals/predict_ml_model_probabilities.json
+++ b/proposals/predict_ml_model_probabilities.json
@@ -1,7 +1,7 @@
 {
-    "id": "predict_random_forest",
-    "summary": "Predict values based on a Random Forest model",
-    "description": "Applies a Random Forest machine learning model to an array and predict a value for it.",
+    "id": "predict_ml_model_probabilities",
+    "summary": "Predict class probabilities using a ML model",
+    "description": "Applies a machine learning model to an array and predicts (class) probabilities for them.",
     "categories": [
         "machine learning",
         "reducer"
@@ -23,7 +23,7 @@
         },
         {
             "name": "model",
-            "description": "A model object that can be trained with the processes ``fit_regr_random_forest()`` (regression) and ``fit_class_random_forest()`` (classification).",
+            "description": "A ML model that can be trained with one of the ML processes such as ``fit_regr_random_forest()``.",
             "schema": {
                 "type": "object",
                 "subtype": "ml-model"
@@ -31,12 +31,15 @@
         }
     ],
     "returns": {
-        "description": "The predicted value. Returns `null` if any of the given values in the array is a no-data value.",
+        "description": "The predicted (class) probabilities. Returns `null` if any of the given values in the array is a no-data value.",
         "schema": {
-            "type": [
-                "number",
-                "null"
-            ]
+            "type": "array",
+            "items": {
+                "type": [
+                    "number",
+                    "null"
+                ]
+            }
         }
     }
 }


### PR DESCRIPTION
As discussed in #368, a first draft to generalize the former random forest specific ML processes for predictions into one process for simple class predictions and another process for class probabilities. Please check carefully, I don't have an ML background ;-)