### PR TITLE
Simplify comparison processes (and add date_difference)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - New processes in proposal state:
+    - `date_difference`
     - `fit_class_random_forest`
     - `fit_regr_random_forest`
     - `flatten_dimensions`
@@ -34,10 +35,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Added a `NoDataAvailable` exception
 - `inspect`: The parameter `message` has been moved to be the second argument. [#369](https://github.com/Open-EO/openeo-processes/issues/369)
 - `save_result`: Added a more concrete `DataCubeEmpty` exception.
+- The comparison processes `eq`, `neq`, `lt`, `lte`, `gt`, `gte` don't support temporal comparison any longer. Instead explicitly use `date_difference`.
 
 ### Removed
 
 - The `examples` folder has been migrated to the [openEO Community Examples](https://github.com/Open-EO/openeo-community-examples/tree/main/processes) repository.
+- `between`: Support for temporal comparison.
 
 ### Fixed
 

--- a/between.json
+++ b/between.json
@@ -16,50 +16,16 @@
         {
             "name": "min",
             "description": "Lower boundary (inclusive) to check against.",
-            "schema": [
-                {
-                    "type": "number"
-                },
-                {
-                    "type": "string",
-                    "format": "date-time",
-                    "subtype": "date-time"
-                },
-                {
-                    "type": "string",
-                    "format": "date",
-                    "subtype": "date"
-                },
-                {
-                    "type": "string",
-                    "format": "time",
-                    "subtype": "time"
-                }
-            ]
+            "schema": {
+                "type": "number"
+            }
         },
         {
             "name": "max",
             "description": "Upper boundary (inclusive) to check against.",
-            "schema": [
-                {
-                    "type": "number"
-                },
-                {
-                    "type": "string",
-                    "format": "date-time",
-                    "subtype": "date-time"
-                },
-                {
-                    "type": "string",
-                    "format": "date",
-                    "subtype": "date"
-                },
-                {
-                    "type": "string",
-                    "format": "time",
-                    "subtype": "time"
-                }
-            ]
+            "schema": {
+                "type": "number"
+            }
         },
         {
             "name": "exclude_max",
@@ -122,47 +88,6 @@
                 "max": 0
             },
             "returns": true
-        },
-        {
-            "arguments": {
-                "x": "00:59:59Z",
-                "min": "01:00:00+01:00",
-                "max": "01:00:00Z"
-            },
-            "returns": true
-        },
-        {
-            "arguments": {
-                "x": "2018-07-23T17:22:45Z",
-                "min": "2018-01-01T00:00:00Z",
-                "max": "2018-12-31T23:59:59Z"
-            },
-            "returns": true
-        },
-        {
-            "arguments": {
-                "x": "2000-01-01",
-                "min": "2018-01-01",
-                "max": "2020-01-01"
-            },
-            "returns": false
-        },
-        {
-            "arguments": {
-                "x": "2018-12-31T17:22:45Z",
-                "min": "2018-01-01",
-                "max": "2018-12-31"
-            },
-            "returns": true
-        },
-        {
-            "arguments": {
-                "x": "2018-12-31T17:22:45Z",
-                "min": "2018-01-01",
-                "max": "2018-12-31",
-                "exclude_max": true
-            },
-            "returns": false
         }
     ],
     "process_graph": {

--- a/eq.json
+++ b/eq.json
@@ -1,7 +1,7 @@
 {
     "id": "eq",
     "summary": "Equal to comparison",
-    "description": "Compares whether `x` is strictly equal to `y`.\n\n**Remarks:**\n\n* Data types MUST be checked strictly. For example, a string with the content *1* is not equal to the number *1*. Nevertheless, an integer *1* is equal to a floating-point number *1.0* as `integer` is a sub-type of `number`.\n* If any operand is `null`, the return value is `null`.\n* If any operand is an array or object, the return value is `false`.\n* Strings are expected to be encoded in UTF-8 by default.\n* Temporal strings are normal strings. To compare temporal strings use ``date_difference()``.",
+    "description": "Compares whether `x` is strictly equal to `y`.\n\n**Remarks:**\n\n* Data types MUST be checked strictly. For example, a string with the content *1* is not equal to the number *1*. Nevertheless, an integer *1* is equal to a floating-point number *1.0* as `integer` is a sub-type of `number`.\n* If any operand is `null`, the return value is `null`.\n* If any operand is an array or object, the return value is `false`.\n* Strings are expected to be encoded in UTF-8 by default.\n* Temporal strings are normal strings. To compare temporal strings as dates/times, use ``date_difference()``.",
     "categories": [
         "texts",
         "comparison"

--- a/eq.json
+++ b/eq.json
@@ -1,7 +1,7 @@
 {
     "id": "eq",
     "summary": "Equal to comparison",
-    "description": "Compares whether `x` is strictly equal to `y`.\n\n**Remarks:**\n\n* Data types MUST be checked strictly. For example, a string with the content *1* is not equal to the number *1*. Nevertheless, an integer *1* is equal to a floating-point number *1.0* as `integer` is a sub-type of `number`.\n* If any operand is `null`, the return value is `null`. Therefore, `eq(null, null)` returns `null` instead of `true`.\n* If any operand is an array or object, the return value is `false`.\n* Strings are expected to be encoded in UTF-8 by default.\n* Temporal strings MUST be compared differently than other strings and MUST NOT be compared based on their string representation due to different possible representations. For example, the time zone representation `Z` (for UTC) has the same meaning as `+00:00`.",
+    "description": "Compares whether `x` is strictly equal to `y`.\n\n**Remarks:**\n\n* Data types MUST be checked strictly. For example, a string with the content *1* is not equal to the number *1*. Nevertheless, an integer *1* is equal to a floating-point number *1.0* as `integer` is a sub-type of `number`.\n* If any operand is `null`, the return value is `null`.\n* If any operand is an array or object, the return value is `false`.\n* Strings are expected to be encoded in UTF-8 by default.\n* Temporal strings are normal strings. To compare temporal strings use ``date_difference()``.",
     "categories": [
         "texts",
         "comparison"
@@ -137,26 +137,10 @@
         },
         {
             "arguments": {
-                "x": "00:00:00+00:00",
-                "y": "00:00:00Z"
-            },
-            "returns": true
-        },
-        {
-            "description": "`y` is not a valid date-time representation and therefore will be treated as a string so that the provided values are not equal.",
-            "arguments": {
-                "x": "2018-01-01T12:00:00Z",
-                "y": "2018-01-01T12:00:00"
+                "x": "2018-01-01T00:00:00Z",
+                "y": "2018-01-01T00:00:00+00:00"
             },
             "returns": false
-        },
-        {
-            "description": "01:00 in the time zone +1 is equal to 00:00 in UTC.",
-            "arguments": {
-                "x": "2018-01-01T00:00:00Z",
-                "y": "2018-01-01T01:00:00+01:00"
-            },
-            "returns": true
         },
         {
             "arguments": {
@@ -172,6 +156,13 @@
                 ]
             },
             "returns": false
+        },
+        {
+            "arguments": {
+                "x": null,
+                "y": null
+            },
+            "returns": null
         }
     ]
 }

--- a/gt.json
+++ b/gt.json
@@ -1,7 +1,7 @@
 {
     "id": "gt",
     "summary": "Greater than comparison",
-    "description": "Compares whether `x` is strictly greater than `y`.\n\n**Remarks:**\n\n* If any operand is `null`, the return value is `null`.\n* If any operand is an array or object, the return value is `false`.\n* If any operand is not a `number` or temporal string (`date`, `time` or `date-time`), the process returns `false`.\n* Temporal strings can *not* be compared based on their string representation due to the time zone / time-offset representations.",
+    "description": "Compares whether `x` is strictly greater than `y`.\n\n**Remarks:**\n\n* If any operand is `null`, the return value is `null`.\n* If any operand is not a `number`, the process returns `false`.\n* Temporal strings are normal strings. To compare temporal strings use ``date_difference()``.",
     "categories": [
         "comparison"
     ],
@@ -61,22 +61,8 @@
         },
         {
             "arguments": {
-                "x": "00:00:00Z",
-                "y": "00:00:00+01:00"
-            },
-            "returns": true
-        },
-        {
-            "arguments": {
-                "x": "1950-01-01T00:00:00Z",
-                "y": "2018-01-01T12:00:00Z"
-            },
-            "returns": false
-        },
-        {
-            "arguments": {
-                "x": "2018-01-01T12:00:00+00:00",
-                "y": "2018-01-01T12:00:00Z"
+                "x": "2018-01-02T00:00:00Z",
+                "y": "2018-01-01T00:00:00Z"
             },
             "returns": false
         },
@@ -93,6 +79,13 @@
                 "y": false
             },
             "returns": false
+        },
+        {
+            "arguments": {
+                "x": null,
+                "y": null
+            },
+            "returns": null
         }
     ]
 }

--- a/gte.json
+++ b/gte.json
@@ -1,7 +1,7 @@
 {
     "id": "gte",
     "summary": "Greater than or equal to comparison",
-    "description": "Compares whether `x` is greater than or equal to `y`.\n\n**Remarks:**\n\n* If any operand is `null`, the return value is `null`. Therefore, `gte(null, null)` returns `null` instead of `true`.\n* If any operand is an array or object, the return value is `false`.\n* If the operands are not equal (see process ``eq()``) and any of them is not a `number` or temporal string (`date`, `time` or `date-time`), the process returns `false`.\n* Temporal strings can *not* be compared based on their string representation due to the time zone / time-offset representations.",
+    "description": "Compares whether `x` is greater than or equal to `y`.\n\n**Remarks:**\n\n* If any operand is `null`, the return value is `null`.\n* If any operand is an array or object, the return value is `false`.\n* If the operands are not equal (see process ``eq()``) and any of them is not a `number`, the process returns `false`.\n* Temporal strings are normal strings. To compare temporal strings use ``date_difference()``.",
     "categories": [
         "comparison"
     ],
@@ -61,24 +61,10 @@
         },
         {
             "arguments": {
-                "x": "00:00:00Z",
-                "y": "00:00:00+01:00"
-            },
-            "returns": true
-        },
-        {
-            "arguments": {
-                "x": "1950-01-01T00:00:00Z",
-                "y": "2018-01-01T12:00:00Z"
+                "x": "2018-01-01T00:00:00Z",
+                "y": "2018-01-01T00:00:00+00:00"
             },
             "returns": false
-        },
-        {
-            "arguments": {
-                "x": "2018-01-01T12:00:00+00:00",
-                "y": "2018-01-01T12:00:00Z"
-            },
-            "returns": true
         },
         {
             "arguments": {
@@ -101,6 +87,13 @@
                 ]
             },
             "returns": false
+        },
+        {
+            "arguments": {
+                "x": null,
+                "y": null
+            },
+            "returns": null
         }
     ],
     "process_graph": {

--- a/lt.json
+++ b/lt.json
@@ -1,7 +1,7 @@
 {
     "id": "lt",
     "summary": "Less than comparison",
-    "description": "Compares whether `x` is strictly less than `y`.\n\n**Remarks:**\n\n* If any operand is `null`, the return value is `null`.\n* If any operand is an array or object, the return value is `false`.\n* If any operand is not a `number` or temporal string (`date`, `time` or `date-time`), the process returns `false`.\n* Temporal strings can *not* be compared based on their string representation due to the time zone / time-offset representations.",
+    "description": "Compares whether `x` is strictly less than `y`.\n\n**Remarks:**\n\n* If any operand is `null`, the return value is `null`.\n* If any operand is not a `number`, the process returns `false`.\n* Temporal strings are normal strings. To compare temporal strings use ``date_difference()``.",
     "categories": [
         "comparison"
     ],
@@ -61,22 +61,8 @@
         },
         {
             "arguments": {
-                "x": "00:00:00+01:00",
-                "y": "00:00:00Z"
-            },
-            "returns": true
-        },
-        {
-            "arguments": {
-                "x": "1950-01-01T00:00:00Z",
-                "y": "2018-01-01T12:00:00Z"
-            },
-            "returns": true
-        },
-        {
-            "arguments": {
-                "x": "2018-01-01T12:00:00+00:00",
-                "y": "2018-01-01T12:00:00Z"
+                "x": "2018-01-01T00:00:00Z",
+                "y": "2018-01-02T00:00:00Z"
             },
             "returns": false
         },
@@ -93,6 +79,13 @@
                 "y": true
             },
             "returns": false
+        },
+        {
+            "arguments": {
+                "x": null,
+                "y": null
+            },
+            "returns": null
         }
     ]
 }

--- a/lte.json
+++ b/lte.json
@@ -1,7 +1,7 @@
 {
     "id": "lte",
     "summary": "Less than or equal to comparison",
-    "description": "Compares whether `x` is less than or equal to `y`.\n\n**Remarks:**\n\n* If any operand is `null`, the return value is `null`. Therefore, `lte(null, null)` returns `null` instead of `true`.\n* If any operand is an array or object, the return value is `false`.\n* If the operands are not equal (see process ``eq()``) and any of them is not a `number` or temporal string (`date`, `time` or `date-time`), the process returns `false`.\n* Temporal strings can *not* be compared based on their string representation due to the time zone / time-offset representations.",
+    "description": "Compares whether `x` is less than or equal to `y`.\n\n**Remarks:**\n\n* If any operand is `null`, the return value is `null`.\n* If any operand is an array or object, the return value is `false`.\n* If the operands are not equal (see process ``eq()``) and any of them is not a `number`, the process returns `false`.\n* Temporal strings are normal strings. To compare temporal strings use ``date_difference()``.",
     "categories": [
         "comparison"
     ],
@@ -61,24 +61,10 @@
         },
         {
             "arguments": {
-                "x": "00:00:00+01:00",
-                "y": "00:00:00Z"
+                "x": "2018-01-01T00:00:00Z",
+                "y": "2018-01-01T00:00:00+00:00"
             },
-            "returns": true
-        },
-        {
-            "arguments": {
-                "x": "1950-01-01T00:00:00Z",
-                "y": "2018-01-01T12:00:00Z"
-            },
-            "returns": true
-        },
-        {
-            "arguments": {
-                "x": "2018-01-01T12:00:00+00:00",
-                "y": "2018-01-01T12:00:00Z"
-            },
-            "returns": true
+            "returns": false
         },
         {
             "arguments": {
@@ -101,6 +87,13 @@
                 ]
             },
             "returns": false
+        },
+        {
+            "arguments": {
+                "x": null,
+                "y": null
+            },
+            "returns": null
         }
     ],
     "process_graph": {

--- a/neq.json
+++ b/neq.json
@@ -1,7 +1,7 @@
 {
     "id": "neq",
     "summary": "Not equal to comparison",
-    "description": "Compares whether `x` is *not* strictly equal to `y`.\n\n**Remarks:**\n\n* Data types MUST be checked strictly. For example, a string with the content *1* is not equal to the number *1*. Nevertheless, an integer *1* is equal to a floating-point number *1.0* as `integer` is a sub-type of `number`.\n* If any operand is `null`, the return value is `null`. Therefore, `neq(null, null)` returns `null` instead of `false`.\n* If any operand is an array or object, the return value is `false`.\n* Strings are expected to be encoded in UTF-8 by default.\n* Temporal strings MUST be compared differently than other strings and MUST NOT be compared based on their string representation due to different possible representations. For example, the time zone representation `Z` (for UTC) has the same meaning as `+00:00`.",
+    "description": "Compares whether `x` is **not** strictly equal to `y`.\n\n**Remarks:**\n\n* Data types MUST be checked strictly. For example, a string with the content *1* is not equal to the number *1*. Nevertheless, an integer *1* is equal to a floating-point number *1.0* as `integer` is a sub-type of `number`.\n* If any operand is `null`, the return value is `null`.\n* If any operand is an array or object, the return value is `false`.\n* Strings are expected to be encoded in UTF-8 by default.\n* Temporal strings are normal strings. To compare temporal strings use ``date_difference()``.",
     "categories": [
         "texts",
         "comparison"
@@ -130,26 +130,10 @@
         },
         {
             "arguments": {
-                "x": "00:00:00+00:00",
-                "y": "00:00:00Z"
-            },
-            "returns": false
-        },
-        {
-            "description": "`y` is not a valid date-time representation and therefore will be treated as a string so that the provided values are not equal.",
-            "arguments": {
-                "x": "2018-01-01T12:00:00Z",
-                "y": "2018-01-01T12:00:00"
+                "x": "2018-01-01T00:00:00Z",
+                "y": "2018-01-01T00:00:00+00:00"
             },
             "returns": true
-        },
-        {
-            "description": "01:00 in the time zone +1 is equal to 00:00 in UTC.",
-            "arguments": {
-                "x": "2018-01-01T00:00:00Z",
-                "y": "2018-01-01T01:00:00+01:00"
-            },
-            "returns": false
         },
         {
             "arguments": {
@@ -165,6 +149,13 @@
                 ]
             },
             "returns": false
+        },
+        {
+            "arguments": {
+                "x": null,
+                "y": null
+            },
+            "returns": null
         }
     ],
     "process_graph": {

--- a/proposals/date_difference.json
+++ b/proposals/date_difference.json
@@ -1,7 +1,7 @@
 {
     "id": "date_difference",
     "summary": "Computes the difference between two time instants",
-    "description": "Computes the difference between two instants in time and returns the difference between them in the unit given.\n\nThe process basically converts the given dates into a numerical timestamps and returns the result of subtracting the other date from the base date. If a given date doesn't include the time, the process assumes that the time component is `00:00:00Z` (i.e. midnight, in UTC). The millisecond part of the times are optional and default to `0` if not given. The process doesn't take daylight saving time (DST) into account as only dates and times in UTC (with potential numerical time zone modifier) are supported.",
+    "description": "Computes the difference between two instants in time and returns the difference between them in the unit given.\n\nThe process converts the given dates into numerical timestamps and returns the result of subtracting the other date from the base date. If a given date doesn't include the time, the process assumes that the time component is `00:00:00Z` (i.e. midnight, in UTC). The millisecond part of the times are optional and default to `0` if not given. The process doesn't take daylight saving time (DST) into account as only dates and times in UTC (with potential numerical time zone modifier) are supported.",
     "categories": [
         "comparison",
         "date & time"

--- a/proposals/date_difference.json
+++ b/proposals/date_difference.json
@@ -1,0 +1,99 @@
+{
+    "id": "date_difference",
+    "summary": "Computes the difference between two time instants",
+    "description": "Computes the difference between two instants in time and returns the difference between them in the unit given.\n\nThe process basically converts the given dates into a numerical timestamps and returns the result of subtracting the other date from the base date. If a given date doesn't include the time, the process assumes that the time component is `00:00:00Z` (i.e. midnight, in UTC). The millisecond part of the times are optional and default to `0` if not given. The process doesn't take daylight saving time (DST) into account as only dates and times in UTC (with potential numerical time zone modifier) are supported.",
+    "categories": [
+        "comparison",
+        "date & time"
+    ],
+    "experimental": true,
+    "parameters": [
+        {
+            "name": "date1",
+            "description": "The base date, optionally with a time component.",
+            "schema": [
+                {
+                    "type": "string",
+                    "format": "date-time",
+                    "subtype": "date-time"
+                },
+                {
+                    "type": "string",
+                    "format": "date",
+                    "subtype": "date"
+                }
+            ]
+        },
+        {
+            "name": "date2",
+            "description": "The other date, optionally with a time component.",
+            "schema": [
+                {
+                    "type": "string",
+                    "format": "date-time",
+                    "subtype": "date-time"
+                },
+                {
+                    "type": "string",
+                    "format": "date",
+                    "subtype": "date"
+                }
+            ]
+        },
+        {
+            "name": "unit",
+            "description": "The unit for the returned value. The following units are available:\n\n- millisecond\n- second - leap seconds are ignored in computations.\n- minute\n- hour\n- day\n- month\n- year",
+            "optional": true,
+            "default": "second",
+            "schema": {
+                "type": "string",
+                "enum": [
+                    "millisecond",
+                    "second",
+                    "minute",
+                    "hour",
+                    "day",
+                    "month",
+                    "year"
+                ]
+            }
+        }
+    ],
+    "returns": {
+        "description": "Returns the difference between date1 and date2 in the given unit (seconds by default), including a fractional part if required.\n\nFor comparison purposes this means:\n\n- If `date1` < `date2`, the returned value is positive.\n- If `date1` = `date2`, the returned value is 0.\n- If `date1` > `date2`, the returned value is negative.",
+        "schema": {
+            "type": "number"
+        }
+    },
+    "examples": [
+        {
+            "arguments": {
+                "date1": "2020-01-01T00:00:00.0Z",
+                "date2": "2020-01-01T00:00:15.5Z"
+            },
+            "returns": 15.5
+        },
+        {
+            "arguments": {
+                "date1": "2020-01-01T00:00:00Z",
+                "date2": "2020-01-01T01:00:00+01:00"
+            },
+            "returns": 0
+        },
+        {
+            "arguments": {
+                "date1": "2020-01-02",
+                "date2": "2020-01-01"
+            },
+            "returns": -86400
+        },
+        {
+            "arguments": {
+                "date1": "2020-01-02",
+                "date2": "2020-01-01",
+                "unit": "day"
+            },
+            "returns": -1
+        }
+    ]
+}

--- a/proposals/date_shift.json
+++ b/proposals/date_shift.json
@@ -1,7 +1,7 @@
 {
     "id": "date_shift",
     "summary": "Manipulates dates and times by addition or subtraction",
-    "description": "Based on a given date (and optionally time), calculates a new date (and time if given) by adding or subtracting a given temporal period.\n\nSome specifics about dates and times need to be taken into account:\n\n* This process doesn't have any effect on the time zone.\n* It doesn't take daylight saving time (DST) into account as only dates and time in UTC (with potential numerical time zone modifier) are supported.\n* Leap years are implemented in a way that computations handle them gracefully (see parameter `unit` for details).\n* Leap seconds are mostly ignored in manipulations as they don't follow a regular pattern. Leap seconds can be passed to the process, but will never be returned.",
+    "description": "Based on a given date (and optionally time), calculates a new date (and time if given) by adding or subtracting a given temporal period.\n\nSome specifics about dates and times need to be taken into account:\n\n* This process doesn't have any effect on the time zone.\n* It doesn't take daylight saving time (DST) into account as only dates and times in UTC (with potential numerical time zone modifier) are supported.\n* Leap years are implemented in a way that computations handle them gracefully (see parameter `unit` for details).\n* Leap seconds are mostly ignored in manipulations as they don't follow a regular pattern. Leap seconds can be passed to the process, but will never be returned.",
     "categories": [
         "date & time"
     ],


### PR DESCRIPTION
This is a proposal to simplify the comparison processes. The discussions in #394 lead me to the conclusion that we may not want to handle date/times in so many processes specifically so that issues can be solved in some central places rather than spreading them into so many processes. Also, the old implementation was a bit suboptimal in that you had to parse the inputs first to detect whether the values are temporal values, potentially making the comparisons slower than needed. Most use-cases can likely be solved with a new process such as `date_difference.`.

This includes a breaking change for the comparison processes. The impact is assumed to be low as most date/time values would usually come from labels in timeseries, but label support seems very limited in back-ends right now. For `between` back-ends can choose to still support the old behavior.

Looking for feedback.