### PR TITLE
Deprecated PROJ definitions for the CRS are not supported any longer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `examples` folder has been migrated to the [openEO Community Examples](https://github.com/Open-EO/openeo-community-examples/tree/main/processes) repository.
 - Deprecated `GeometryCollections` are not supported any longer. [#389](https://github.com/Open-EO/openeo-processes/issues/389)
+- Deprecated PROJ definitions for the CRS are not supported any longer.
 
 ### Fixed
 

--- a/filter_bbox.json
+++ b/filter_bbox.json
@@ -83,7 +83,7 @@
                         "default": null
                     },
                     "crs": {
-                        "description": "Coordinate reference system of the extent, specified as as [EPSG code](http://www.epsg-registry.org/), [WKT2 (ISO 19162) string](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html) or [PROJ definition (deprecated)](https://proj.org/usage/quickstart.html). Defaults to `4326` (EPSG code 4326) unless the client explicitly requests a different coordinate reference system.",
+                        "description": "Coordinate reference system of the extent, specified as as [EPSG code](http://www.epsg-registry.org/) or [WKT2 CRS string](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html). Defaults to `4326` (EPSG code 4326) unless the client explicitly requests a different coordinate reference system.",
                         "anyOf": [
                             {
                                 "title": "EPSG Code",
@@ -98,12 +98,6 @@
                                 "title": "WKT2",
                                 "type": "string",
                                 "subtype": "wkt2-definition"
-                            },
-                            {
-                                "title": "PROJ definition",
-                                "type": "string",
-                                "subtype": "proj-definition",
-                                "deprecated": true
                             }
                         ],
                         "default": 4326

--- a/load_collection.json
+++ b/load_collection.json
@@ -64,7 +64,7 @@
                             "default": null
                         },
                         "crs": {
-                            "description": "Coordinate reference system of the extent, specified as as [EPSG code](http://www.epsg-registry.org/), [WKT2 (ISO 19162) string](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html) or [PROJ definition (deprecated)](https://proj.org/usage/quickstart.html). Defaults to `4326` (EPSG code 4326) unless the client explicitly requests a different coordinate reference system.",
+                            "description": "Coordinate reference system of the extent, specified as as [EPSG code](http://www.epsg-registry.org/) or [WKT2 CRS string](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html). Defaults to `4326` (EPSG code 4326) unless the client explicitly requests a different coordinate reference system.",
                             "anyOf": [
                                 {
                                     "title": "EPSG Code",
@@ -79,12 +79,6 @@
                                     "title": "WKT2",
                                     "type": "string",
                                     "subtype": "wkt2-definition"
-                                },
-                                {
-                                    "title": "PROJ definition",
-                                    "type": "string",
-                                    "subtype": "proj-definition",
-                                    "deprecated": true
                                 }
                             ],
                             "default": 4326

--- a/meta/subtype-schemas.json
+++ b/meta/subtype-schemas.json
@@ -14,7 +14,7 @@
             "type": "object",
             "subtype": "bounding-box",
             "title": "Bounding Box",
-            "description": "A bounding box with the required fields `west`, `south`, `east`, `north` and optionally `base`, `height`, `crs`. The `crs` is a EPSG code, a WKT2:2018 string or a PROJ definition (deprecated).",
+            "description": "A bounding box with the required fields `west`, `south`, `east`, `north` and optionally `base`, `height`, `crs`. The `crs` is a EPSG code or a WKT2:2018 string.",
             "required": [
                 "west",
                 "south",
@@ -55,16 +55,13 @@
                     "default": null
                 },
                 "crs": {
-                    "description": "Coordinate reference system of the extent, specified as as [EPSG code](http://www.epsg-registry.org/), [WKT2 (ISO 19162) string](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html) or [PROJ definition (deprecated)](https://proj.org/usage/quickstart.html). Defaults to `4326` (EPSG code 4326) unless the client explicitly requests a different coordinate reference system.",
+                    "description": "Coordinate reference system of the extent, specified as as [EPSG code](http://www.epsg-registry.org/) or [WKT2 CRS string](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html). Defaults to `4326` (EPSG code 4326) unless the client explicitly requests a different coordinate reference system.",
                     "anyOf": [
                         {
                             "$ref": "#/definitions/epsg-code"
                         },
                         {
                             "$ref": "#/definitions/wkt2-definition"
-                        },
-                        {
-                            "$ref": "#/definitions/proj-definition"
                         }
                     ],
                     "default": 4326
@@ -285,12 +282,6 @@
                     }
                 }
             }
-        },
-        "proj-definition": {
-            "type": "string",
-            "subtype": "proj-definition",
-            "title": "PROJ definition",
-            "description": "**DEPRECATED.** Specifies details about cartographic projections as [PROJ](https://proj.org/usage/quickstart.html) definition."
         },
         "raster-cube": {
             "type": "object",

--- a/proposals/load_result.json
+++ b/proposals/load_result.json
@@ -75,7 +75,7 @@
                             "default": null
                         },
                         "crs": {
-                            "description": "Coordinate reference system of the extent, specified as as [EPSG code](http://www.epsg-registry.org/), [WKT2 (ISO 19162) string](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html) or [PROJ definition (deprecated)](https://proj.org/usage/quickstart.html). Defaults to `4326` (EPSG code 4326) unless the client explicitly requests a different coordinate reference system.",
+                            "description": "Coordinate reference system of the extent, specified as as [EPSG code](http://www.epsg-registry.org/) or [WKT2 CRS string](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html). Defaults to `4326` (EPSG code 4326) unless the client explicitly requests a different coordinate reference system.",
                             "anyOf": [
                                 {
                                     "title": "EPSG Code",
@@ -90,12 +90,6 @@
                                     "title": "WKT2",
                                     "type": "string",
                                     "subtype": "wkt2-definition"
-                                },
-                                {
-                                    "title": "PROJ definition",
-                                    "type": "string",
-                                    "subtype": "proj-definition",
-                                    "deprecated": true
                                 }
                             ],
                             "default": 4326

--- a/resample_spatial.json
+++ b/resample_spatial.json
@@ -49,7 +49,7 @@
         },
         {
             "name": "projection",
-            "description": "Warps the data cube to the target projection, specified as as [EPSG code](http://www.epsg-registry.org/), [WKT2 (ISO 19162) string](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html), [PROJ definition (deprecated)](https://proj.org/usage/quickstart.html). By default (`null`), the projection is not changed.",
+            "description": "Warps the data cube to the target projection, specified as as [EPSG code](http://www.epsg-registry.org/) or [WKT2 CRS string](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html). By default (`null`), the projection is not changed.",
             "schema": [
                 {
                     "title": "EPSG Code",
@@ -64,12 +64,6 @@
                     "title": "WKT2",
                     "type": "string",
                     "subtype": "wkt2-definition"
-                },
-                {
-                    "title": "PROJ definition",
-                    "type": "string",
-                    "subtype": "proj-definition",
-                    "deprecated": true
                 },
                 {
                     "title": "Don't change projection",


### PR DESCRIPTION
PROJ strings: They were deprecated in 1.x and now get removed in 2.0