### PR TITLE
`sqrt`: Clarified that NaN is returned for negative numbers #474

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased / Draft
 
+### Fixed
+
+- `sqrt`: Clarified that NaN is returned for negative numbers.
+
 ## [2.0.0-rc.1] - 2023-05-25
 
 ### Added

--- a/sqrt.json
+++ b/sqrt.json
@@ -1,7 +1,7 @@
 {
     "id": "sqrt",
     "summary": "Square root",
-    "description": "Computes the square root of a real number `x`, which is equal to calculating `x` to the power of *0.5*.\n\nA square root of x is a number a such that *`a² = x`*. Therefore, the square root is the inverse function of a to the power of 2, but only for *a >= 0*.\n\nThe no-data value `null` is passed through and therefore gets propagated.",
+    "description": "Computes the square root of a real number `x`, which is equal to calculating `x` to the power of *0.5*. For negative `x`, the process returns `NaN`.\n\nA square root of x is a number a such that *`a² = x`*. Therefore, the square root is the inverse function of a to the power of 2, but only for *a >= 0*.\n\nThe no-data value `null` is passed through and therefore gets propagated.",
     "categories": [
         "math",
         "math > exponential & logarithmic"
@@ -58,6 +58,11 @@
             "rel": "about",
             "href": "http://mathworld.wolfram.com/SquareRoot.html",
             "title": "Square root explained by Wolfram MathWorld"
+        },
+        {
+            "rel": "about",
+            "href": "https://ieeexplore.ieee.org/document/8766229",
+            "title": "IEEE Standard 754-2019 for Floating-Point Arithmetic"
         }
     ],
     "process_graph": {


### PR DESCRIPTION
Fixes #474 

Related to #468 