### PR TITLE
`array_append`: Add number type for labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0-rc.1] - 2023-05-25
 
+### Fixed
+
+- `array_append`: Added `number` type for labels to be consistent with other processes. Default to numerical index instead of string.
+
 ### Added
 
 - New processes in proposal state:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `array_append`: Added `number` type for labels to be consistent with other processes. Default to numerical index instead of string.
+- `array_append`: Added `number` type for labels to be consistent with other processes. Default to numerical index instead of string. Clarify that the `label` parameter only applies to labeled arrays.
 
 ### Added
 

--- a/array_append.json
+++ b/array_append.json
@@ -25,15 +25,20 @@
         },
         {
             "name": "label",
-            "description": "If the given array is a labeled array, a new label for the new value should be given. If not given or `null`, the array index as string is used as the label. If in any case the label exists, a `LabelExists` exception is thrown.",
+            "description": "If the given array is a labeled array, a new label for the new value should be given. If not given or `null`, the array index as number is used as the label. If in any case the label exists, a `LabelExists` exception is thrown.",
             "optional": true,
             "default": null,
-            "schema": {
-                "type": [
-                    "string",
-                    "null"
-                ]
-            }
+            "schema": [
+                {
+                    "type": "number"
+                },
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ]
         }
     ],
     "returns": {

--- a/array_append.json
+++ b/array_append.json
@@ -25,7 +25,7 @@
         },
         {
             "name": "label",
-            "description": "If the given array is a labeled array, a new label for the new value should be given. If not given or `null`, the array index as number is used as the label. If in any case the label exists, a `LabelExists` exception is thrown.",
+            "description": "Provides a label for the new value. If not given or `null`, the natural next array index as number is used as the label. If in any case the label exists, a `LabelExists` exception is thrown.\n\nThis parameter only applies if the given array is a labeled array. If a non-null values is provided and the array is not labeled, an `ArrayNotLabeled` exception is thrown.",
             "optional": true,
             "default": null,
             "schema": [
@@ -53,6 +53,9 @@
     "exceptions": {
         "LabelExists": {
             "message": "An array element with the specified label already exists."
+        },
+        "ArrayNotLabeled": {
+            "message": "A label can't be provided as the given array is not labeled."
         }
     },
     "examples": [


### PR DESCRIPTION
`array_append`: Added `number` type for labels to be consistent with other processes. Default to numerical index instead of string.