### PR TITLE
`load_stac`: Clarify the `properties` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `eq` and `neq`: Explicitly set the minimum value for the `delta` parameter.
 - `filter_bbox`, `load_collection`, `load_stac`: Clarified that the bounding box is reprojected to the CRS of the spatial data cube dimensions if required.
 - `filter_spatial`: Clarified that masking is applied using the given geometries. [#469](https://github.com/Open-EO/openeo-processes/issues/469)
+- `load_stac`: Clarify handling of the `properties` parameter in the context of STAC APIs and static catalogs. [#536](https://github.com/Open-EO/openeo-processes/issues/536)
 - `load_collection` and `load_stac`: Clarified that scale and offset are not applied automatically when loading the data. [#503](https://github.com/Open-EO/openeo-processes/issues/503)
 - `mod`: Clarified behavior for y = 0
 - `sqrt`: Clarified that NaN is returned for negative numbers.

--- a/dev/.words
+++ b/dev/.words
@@ -37,6 +37,7 @@ signum
 STAC
 catalog
 Catalog
+catalogs
 summand
 UDFs
 gdalwarp
@@ -49,3 +50,5 @@ date1
 date2
 favor
 Undeploy
+queryable
+Queryables

--- a/proposals/load_stac.json
+++ b/proposals/load_stac.json
@@ -186,7 +186,7 @@
         },
         {
             "name": "properties",
-            "description": "Limits the data by metadata properties to include only data in the data cube which all given conditions return `true` for (AND operation).\n\nSpecify key-value-pairs with the key being the name of the metadata property, which can be retrieved with the openEO Data Discovery for Collections. The value must be a condition (user-defined process) to be evaluated against a STAC API. This parameter is not supported for static STAC.",
+            "description": "Limits the data by metadata properties to include only data in the data cube which all given conditions return `true` for (AND operation).\n\nSpecify key-value-pairs with the key being the name of the queryable (for STAC APIs) or the metadata property name (for static STAC catalogs). Queryables can be retrieved from the Queryables endpoint of the STAC API and are often but not always aligned with the metadata property names. The value must be a condition (user-defined process) to be evaluated against a STAC API or static catalog. This parameter may not be supported for static STAC catalogs.",
             "schema": [
                 {
                     "type": "object",

--- a/proposals/load_stac.json
+++ b/proposals/load_stac.json
@@ -186,7 +186,7 @@
         },
         {
             "name": "properties",
-            "description": "Limits the data by metadata properties to include only data in the data cube which all given conditions return `true` for (AND operation).\n\nSpecify key-value-pairs with the key being the name of the queryable (for STAC APIs) or the metadata property name (for static STAC catalogs). Queryables can be retrieved from the Queryables endpoint of the STAC API and are often but not always aligned with the metadata property names. The value must be a condition (user-defined process) to be evaluated against a STAC API or static catalog. This parameter may not be supported for static STAC catalogs.",
+            "description": "Limits the data by metadata properties to include only data in the data cube which all given conditions return `true` for (AND operation).\n\nSpecify key-value-pairs with the key being the name of the queryable (for STAC APIs implementing the Filter Extension) or the metadata property name (for static STAC catalogs or STAC APIs implementing the Query Extension). Queryables can be retrieved from the Queryables endpoint of the STAC API and are often but not always aligned with the metadata property names. The value must be a condition (user-defined process) to be evaluated against a STAC API or static catalog. This parameter throws a `PropertiesUnsupported` exception if querying is not implemented for static STAC catalogs or STAC APIs that don't support the Filter or Query Extension.",
             "schema": [
                 {
                     "type": "object",
@@ -292,6 +292,9 @@
         },
         "TemporalExtentEmpty": {
             "message": "The temporal extent is empty. The second instant in time must always be greater/later than the first instant in time."
+        },
+        "PropertiesUnsupported": {
+            "message": "The `properties` parameter is not supported for the given STAC entity."
         }
     },
     "links": [


### PR DESCRIPTION
`load_stac`: Clarify handling of the `properties` parameter in the context of STAC APIs and static catalogs.

Closes #536